### PR TITLE
`findInReq()` now accepts dot notation for fields. So you can pass `?…

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ To run tests, you first must [start a Mongo server on port 27017](https://mongod
 
 ## Changelog
 
+* 3.1.0 `findInReq()` now accepts dot notation for fields. So you can pass `?fields=users.userId` to only turn the `userId` property for `users` in the response.
+
 * 3.0.1 Fixed bug where the _id field was always returned when a paginatedField was used.
 
 * 3.0.0 Breaking API change: `find()` no longer accepts a string for `limit`. Added `findWithReq`.

--- a/spec/utils/mongoFieldsPickSpec.js
+++ b/spec/utils/mongoFieldsPickSpec.js
@@ -1,0 +1,13 @@
+var dotFieldIntersect = require('../../src/utils/dotFieldIntersect');
+
+describe('dotFieldIntersect', () => {
+  it('should work', () => {
+    expect(dotFieldIntersect(['obj1', 'obj2'], ['obj1'])).toEqual(['obj1']);
+    expect(dotFieldIntersect(['obj1'], [])).toEqual([]);
+    expect(dotFieldIntersect(['obj'], ['obj.nested', 'obj.nested2'])).toEqual(['obj.nested', 'obj.nested2']);
+    expect(dotFieldIntersect(['obj.nested', 'obj.nested2'], ['obj'])).toEqual(['obj.nested', 'obj.nested2']);
+    expect(dotFieldIntersect(['obj', 'obj2'], ['obj.one', 'obj.four.five'])).toEqual(['obj.one', 'obj.four.five']);
+    expect(dotFieldIntersect(['obj.nested'], ['obj.nested.morenested', 'obj.nested.morenested1'])).toEqual(['obj.nested.morenested', 'obj.nested.morenested1']);
+    expect(dotFieldIntersect(['obj.nested', 'obj2'], ['obj'])).toEqual(['obj.nested']);
+  });
+});

--- a/src/findWithReq.js
+++ b/src/findWithReq.js
@@ -1,4 +1,5 @@
 var find = require('./find');
+var dotFieldIntersect = require('./utils/dotFieldIntersect');
 var _ = require('underscore');
 
 /**
@@ -38,14 +39,16 @@ module.exports = function(req, collection, params, done) {
   }
 
   if (!_.isEmpty(req.query.fields)) {
+    var fields = req.query.fields.split(',');
     if (params.fields) {
-      params.fields = _.pick(params.fields, req.query.fields.split(','));
-    } else {
-      params.fields = req.query.fields.split(',').reduce((accum, field) => {
-        accum[field] = 1;
-        return accum;
-      }, {});
+      // Don't trust fields passed in the querystring, so whitelist them against the
+      // fields defined in parameters.
+      fields = dotFieldIntersect(Object.keys(params.fields), fields);
     }
+    params.fields = fields.reduce((accum, field) => {
+      accum[field] = 1;
+      return accum;
+    }, {});
   }
 
   find(collection, params, done);

--- a/src/utils/dotFieldIntersect.js
+++ b/src/utils/dotFieldIntersect.js
@@ -1,0 +1,44 @@
+var _ = require('underscore');
+
+/**
+ * Returns the narrowest set of intersecting "dot notation fields" given two arrays.
+ * So given the two properties 'object' and 'object.nestedproperty', the intersection
+ * is 'object.nestedproperty' because that's the property with the narrowest scope.
+ * This is useful to apply a whitelist to a Mongo projection. So if the user asks for
+ * all of 'object' to be returned, you can limit it to just 'object.nestedproperty'.
+ */
+module.exports = function(dotFields1, dotFields2) {
+  var intersection = [];
+
+  // TODO: I'm sure this can be made more efficient.
+
+  dotFields1.forEach(dotField1 => {
+    dotFields2.forEach(dotField2 => {
+      if (sameOrBroader(dotField1, dotField2)) {
+        intersection.push(dotField1);
+      }
+    });
+  });
+
+  // Check the reverse.
+  dotFields2.forEach(dotField2 => {
+    dotFields1.forEach(dotField1 => {
+      if (sameOrBroader(dotField2, dotField1)) {
+        intersection.push(dotField2);
+      }
+    });
+  });
+
+  return _.uniq(intersection);
+};
+
+// Helper returns true if the 
+function sameOrBroader(dotField1, dotField2) {
+  var dotField1Parts = dotField1.split('.');
+  var dotField2Parts = dotField2.split('.');
+  if (dotField1Parts.length < dotField2Parts.length) return false;
+  for (let i = 0; i < dotField2Parts.length; i++) {
+    if (dotField1Parts[i] !== dotField2Parts[i]) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
…fields=users.userId` to only turn the `userId` property for `users` in the response.