### PR TITLE
Fix bug where calling `find` with a `next` does not work when paginated field has dot notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "ava",
     "lint": "eslint .",
     "babelBuild": "babel src -d dist/node",
+    "babelWatch": "babel --watch src -d dist/node",
     "prepublish": "yarn run babelBuild"
   },
   "repository": {
@@ -36,6 +37,7 @@
   "dependencies": {
     "base64-url": "^1.3.2",
     "mongodb-extended-json": "^1.7.1",
+    "object-path": "^0.11.4",
     "semver": "^5.4.1",
     "underscore": "^1.8.3"
   },

--- a/src/find.js
+++ b/src/find.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var objectPath = require('object-path');
 var config = require('./config');
 var bsonUrlEncoding = require('./utils/bsonUrlEncoding');
 
@@ -146,17 +147,19 @@ module.exports = async function(collection, params) {
   };
 
   if (response.previous) {
+    var previousPaginatedField = objectPath.get(response.previous, params.paginatedField);
     if (shouldSecondarySortOnId) {
-      response.previous = bsonUrlEncoding.encode([response.previous[params.paginatedField], response.previous._id]);
+      response.previous = bsonUrlEncoding.encode([previousPaginatedField, response.previous._id]);
     } else {
-      response.previous = bsonUrlEncoding.encode(response.previous[params.paginatedField]);
+      response.previous = bsonUrlEncoding.encode(previousPaginatedField);
     }
   }
   if (response.next) {
+    var nextPaginatedField = objectPath.get(response.next, params.paginatedField);
     if (shouldSecondarySortOnId) {
-      response.next = bsonUrlEncoding.encode([response.next[params.paginatedField], response.next._id]);
+      response.next = bsonUrlEncoding.encode([nextPaginatedField, response.next._id]);
     } else {
-      response.next = bsonUrlEncoding.encode(response.next[params.paginatedField]);
+      response.next = bsonUrlEncoding.encode(nextPaginatedField);
     }
   }
 


### PR DESCRIPTION
When passing a paginated field that has a dot notation e.g. `start.date`, the first set of results returns fine, but when using `next` or `previous`, the results are not returned correctly. This is a fix for that issue.