### PR TITLE
[Feature] Paginate by _id

### DIFF
--- a/spec/findSpec.js
+++ b/spec/findSpec.js
@@ -127,7 +127,7 @@ describe('find', (it) => {
 
   it.describe('basic usage', (it) => {
     it.describe('test with Mongo object ids', (it) => {
-      it('should query first few pages', async (t) => {
+      it('should query first few pages with next/previous', async (t) => {
         const collection = t.context.db.collection('test_paging');
         // First page of 3
         let res = await paging.find(collection, {
@@ -193,7 +193,73 @@ describe('find', (it) => {
         t.true(res.hasNext);
       });
 
-      it('should handle hitting the end', async (t) => {
+      it('should query first few pages with after/before', async (t) => {
+        const collection = t.context.db.collection('test_paging');
+        // First page of 3
+        let res = await paging.find(collection, {
+          limit: 3
+        });
+
+        t.is(res.results.length, 3);
+        t.is(res.results[0].counter, 8);
+        t.is(res.results[1].counter, 7);
+        t.is(res.results[2].counter, 6);
+        t.false(res.hasPrevious);
+        t.true(res.hasNext);
+
+        // Go forward 3
+        res = await paging.find(collection, {
+          limit: 3,
+          after: res.results[res.results.length -1]._id
+        });
+
+        t.is(res.results.length, 3);
+        t.is(res.results[0].counter, 5);
+        t.is(res.results[1].counter, 4);
+        t.is(res.results[2].counter, 3);
+        t.true(res.hasPrevious);
+        t.true(res.hasNext);
+
+        // Go forward another 3
+        res = await paging.find(collection, {
+          limit: 3,
+          after: res.results[res.results.length -1]._id
+        });
+
+        t.is(res.results.length, 2);
+        t.is(res.results[0].counter, 2);
+        t.is(res.results[1].counter, 1);
+        t.true(res.hasPrevious);
+        t.false(res.hasNext);
+
+        // Now back up 3
+        res = await paging.find(collection, {
+          limit: 3,
+          before: res.results[0]._id
+        });
+
+        t.is(res.results.length, 3);
+        t.is(res.results[0].counter, 5);
+        t.is(res.results[1].counter, 4);
+        t.is(res.results[2].counter, 3);
+        t.true(res.hasPrevious);
+        t.true(res.hasNext);
+
+        // Now back up 3 more
+        res = await paging.find(collection, {
+          limit: 3,
+          before: res.results[0]._id
+        });
+
+        t.is(res.results.length, 3);
+        t.is(res.results[0].counter, 8);
+        t.is(res.results[1].counter, 7);
+        t.is(res.results[2].counter, 6);
+        t.false(res.hasPrevious);
+        t.true(res.hasNext);
+      });
+
+      it('should handle hitting the end with next/previous', async (t) => {
         const collection = t.context.db.collection('test_paging');
         // First page of 2
         var res = await paging.find(collection, {
@@ -233,7 +299,47 @@ describe('find', (it) => {
         t.false(res.hasNext);
       });
 
-      it('should handle hitting the beginning', async (t) => {
+      it('should handle hitting the end with after/before', async (t) => {
+        const collection = t.context.db.collection('test_paging');
+        // First page of 2
+        var res = await paging.find(collection, {
+          limit: 4
+        });
+
+        t.is(res.results.length, 4);
+        t.is(res.results[0].counter, 8);
+        t.is(res.results[1].counter, 7);
+        t.is(res.results[2].counter, 6);
+        t.is(res.results[3].counter, 5);
+        t.false(res.hasPrevious);
+        t.true(res.hasNext);
+
+        // Go forward 2
+        res = await paging.find(collection, {
+          limit: 3,
+          after: res.results[res.results.length -1]._id
+        });
+
+        t.is(res.results.length, 3);
+        t.is(res.results[0].counter, 4);
+        t.is(res.results[1].counter, 3);
+        t.is(res.results[2].counter, 2);
+        t.true(res.hasPrevious);
+        t.true(res.hasNext);
+
+        // Go forward another 1, results should be empty.
+        res = await paging.find(collection, {
+          limit: 2,
+          after: res.results[res.results.length -1]._id
+        });
+
+        t.is(res.results.length, 1);
+        t.is(res.results[0].counter, 1);
+        t.true(res.hasPrevious);
+        t.false(res.hasNext);
+      });
+
+      it('should handle hitting the beginning with next/previous', async (t) => {
         const collection = t.context.db.collection('test_paging');
         // First page of 2
         var res = await paging.find(collection, {
@@ -265,6 +371,49 @@ describe('find', (it) => {
         res = await paging.find(collection, {
           limit: 100,
           previous: res.previous
+        });
+
+        t.is(res.results.length, 4);
+        t.is(res.results[0].counter, 8);
+        t.is(res.results[1].counter, 7);
+        t.is(res.results[2].counter, 6);
+        t.is(res.results[3].counter, 5);
+        t.false(res.hasPrevious);
+        t.true(res.hasNext);
+      });
+
+      it('should handle hitting the beginning with after/before', async (t) => {
+        const collection = t.context.db.collection('test_paging');
+        // First page of 2
+        var res = await paging.find(collection, {
+          limit: 4
+        });
+
+        t.is(res.results.length, 4);
+        t.is(res.results[0].counter, 8);
+        t.is(res.results[1].counter, 7);
+        t.is(res.results[2].counter, 6);
+        t.is(res.results[3].counter, 5);
+        t.false(res.hasPrevious);
+        t.true(res.hasNext);
+
+        // Go forward 2
+        res = await paging.find(collection, {
+          limit: 3,
+          after: res.results[res.results.length -1]._id
+        });
+
+        t.is(res.results.length, 3);
+        t.is(res.results[0].counter, 4);
+        t.is(res.results[1].counter, 3);
+        t.is(res.results[2].counter, 2);
+        t.true(res.hasPrevious);
+        t.true(res.hasNext);
+
+        // Go back to beginning.
+        res = await paging.find(collection, {
+          limit: 100,
+          before: res.results[0]._id
         });
 
         t.is(res.results.length, 4);
@@ -322,7 +471,7 @@ describe('find', (it) => {
         t.false(res.hasPrevious);
       });
 
-      it('should respect sortAscending option', async (t) => {
+      it('should respect sortAscending option with next/previous', async (t) => {
         const collection = t.context.db.collection('test_paging');
         // First page of 3
         var res = await paging.find(collection, {
@@ -393,11 +542,82 @@ describe('find', (it) => {
         t.true(res.hasNext);
       });
 
+      it('should respect sortAscending option with after/before', async (t) => {
+        const collection = t.context.db.collection('test_paging');
+        // First page of 3
+        var res = await paging.find(collection, {
+          limit: 3,
+          sortAscending: true
+        });
+
+        t.is(res.results.length, 3);
+        t.is(res.results[0].counter, 1);
+        t.is(res.results[1].counter, 2);
+        t.is(res.results[2].counter, 3);
+        t.false(res.hasPrevious);
+        t.true(res.hasNext);
+
+        // Go forward 3
+        res = await paging.find(collection, {
+          limit: 3,
+          after: res.results[res.results.length -1]._id,
+          sortAscending: true
+        });
+
+        t.is(res.results.length, 3);
+        t.is(res.results[0].counter, 4);
+        t.is(res.results[1].counter, 5);
+        t.is(res.results[2].counter, 6);
+        t.true(res.hasPrevious);
+        t.true(res.hasNext);
+
+        // Go forward another 3
+        res = await paging.find(collection, {
+          limit: 3,
+          after: res.results[res.results.length -1]._id,
+          sortAscending: true
+        });
+
+        t.is(res.results.length, 2);
+        t.is(res.results[0].counter, 7);
+        t.is(res.results[1].counter, 8);
+        t.true(res.hasPrevious);
+        t.false(res.hasNext);
+
+        // // Now back up 3
+        res = await paging.find(collection, {
+          limit: 3,
+          before: res.results[0]._id,
+          sortAscending: true
+        });
+
+        t.is(res.results.length, 3);
+        t.is(res.results[0].counter, 4);
+        t.is(res.results[1].counter, 5);
+        t.is(res.results[2].counter, 6);
+        t.true(res.hasPrevious);
+        t.true(res.hasNext);
+
+        // Now back up 3 more
+        res = await paging.find(collection, {
+          limit: 3,
+          before: res.results[0]._id,
+          sortAscending: true
+        });
+
+        t.is(res.results.length, 3);
+        t.is(res.results[0].counter, 1);
+        t.is(res.results[1].counter, 2);
+        t.is(res.results[2].counter, 3);
+        t.false(res.hasPrevious);
+        t.true(res.hasNext);
+      });
+
     });
   });
 
   it.describe('test with custom fields', (it) => {
-    it('should query first few pages', async (t) => {
+    it('should query first few pages with next/previous', async (t) => {
       const collection = t.context.db.collection('test_paging_custom_fields');
       // First page of 2
       var res = await paging.find(collection, {
@@ -451,6 +671,60 @@ describe('find', (it) => {
       t.true(res.hasNext);
     });
 
+    it('should query first few pages with after/before', async (t) => {
+      const collection = t.context.db.collection('test_paging_custom_fields');
+      // First page of 2
+      var res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'timestamp'
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 6);
+      t.is(res.results[1].counter, 5);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 2
+      res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'timestamp',
+        after: res.results[res.results.length -1]._id
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 3);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward another 2
+      res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'timestamp',
+        after: res.results[res.results.length -1]._id
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 2);
+      t.is(res.results[1].counter, 1);
+      t.true(res.hasPrevious);
+      t.false(res.hasNext);
+
+      // Now back up 2
+      res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'timestamp',
+        before: res.results[0]._id
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 3);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+    });
+
     it('should not include the paginatedField in the results if not desired', async (t) => {
       const collection = t.context.db.collection('test_paging_custom_fields');
       var res = await paging.find(collection, {
@@ -464,7 +738,7 @@ describe('find', (it) => {
       t.true(res.hasNext);
     });
 
-    it('should not overwrite $or used in a query', async (t) => {
+    it('should not overwrite $or used in a query with next/previous', async (t) => {
       const collection = t.context.db.collection('test_paging_custom_fields');
       // First page of 2
       var res = await paging.find(collection, {
@@ -492,10 +766,39 @@ describe('find', (it) => {
       t.true(res.hasPrevious);
       t.false(res.hasNext);
     });
+
+    it('should not overwrite $or used in a query with after/before', async (t) => {
+      const collection = t.context.db.collection('test_paging_custom_fields');
+      // First page of 2
+      var res = await paging.find(collection, {
+        query: { $or: [{ counter: { $gt: 3 } }] },
+        limit: 2,
+        paginatedField: 'timestamp'
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 6);
+      t.is(res.results[1].counter, 5);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 2
+      res = await paging.find(collection, {
+        query: { $or: [{ counter: { $gt: 3 } }] },
+        limit: 2,
+        paginatedField: 'timestamp',
+        after: res.results[res.results.length -1]._id
+      });
+
+      t.is(res.results.length, 1);
+      t.is(res.results[0].counter, 4);
+      t.true(res.hasPrevious);
+      t.false(res.hasNext);
+    });
   });
 
   it.describe('test with duplicate values for paginated field', (it) => {
-    it('should query first few pages', async (t) => {
+    it('should query first few pages with next/previous', async (t) => {
       const collection = t.context.db.collection('test_duplicate_custom_fields');
       // First page of 2
       var res = await paging.find(collection, {
@@ -549,6 +852,60 @@ describe('find', (it) => {
       t.true(res.hasNext);
     });
 
+    it('should query first few pages with after/before', async (t) => {
+      const collection = t.context.db.collection('test_duplicate_custom_fields');
+      // First page of 2
+      var res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'timestamp'
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 6);
+      t.is(res.results[1].counter, 5);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 2
+      res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'timestamp',
+        after: res.results[res.results.length -1]._id
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 3);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward another 2
+      res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'timestamp',
+        after: res.results[res.results.length -1]._id
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 2);
+      t.is(res.results[1].counter, 1);
+      t.true(res.hasPrevious);
+      t.false(res.hasNext);
+
+      // Now back up 2
+      res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'timestamp',
+        before: res.results[0]._id
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 3);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+    });
+
     it('should not include fields not desired', async (t) => {
       const collection = t.context.db.collection('test_duplicate_custom_fields');
       var res = await paging.find(collection, {
@@ -566,7 +923,7 @@ describe('find', (it) => {
       t.true(res.hasNext);
     });
 
-    it('should respect sortAscending', async (t) => {
+    it('should respect sortAscending with next/previous', async (t) => {
       const collection = t.context.db.collection('test_duplicate_custom_fields');
       // First page of 2
       var res = await paging.find(collection, {
@@ -623,10 +980,68 @@ describe('find', (it) => {
       t.true(res.hasPrevious);
       t.true(res.hasNext);
     });
+
+    it('should respect sortAscending with after/before', async (t) => {
+      const collection = t.context.db.collection('test_duplicate_custom_fields');
+      // First page of 2
+      var res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'timestamp',
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 1);
+      t.is(res.results[1].counter, 2);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 2
+      res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'timestamp',
+        after: res.results[res.results.length -1]._id,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 3);
+      t.is(res.results[1].counter, 4);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward another 2
+      res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'timestamp',
+        after: res.results[res.results.length -1]._id,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 5);
+      t.is(res.results[1].counter, 6);
+      t.true(res.hasPrevious);
+      t.false(res.hasNext);
+
+      // Now back up 2
+      res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'timestamp',
+        before: res.results[0]._id,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 3);
+      t.is(res.results[1].counter, 4);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+    });
   });
 
   it.describe('test with dates', (it) => {
-    it('should query first few pages', async (t) => {
+    it('should query first few pages with next/previous', async (t) => {
       const collection = t.context.db.collection('test_paging_date');
       // First page of 2
       var res = await paging.find(collection, {
@@ -645,6 +1060,34 @@ describe('find', (it) => {
         limit: 2,
         paginatedField: 'date',
         next: res.next
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 2);
+      t.is(res.results[1].counter, 1);
+      t.true(res.hasPrevious);
+      t.false(res.hasNext);
+    });
+
+    it('should query first few pages with after/before', async (t) => {
+      const collection = t.context.db.collection('test_paging_date');
+      // First page of 2
+      var res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'date'
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 3);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 2
+      res = await paging.find(collection, {
+        limit: 2,
+        paginatedField: 'date',
+        after: res.results[res.results.length -1]._id
       });
 
       t.is(res.results.length, 2);

--- a/spec/findSpec.js
+++ b/spec/findSpec.js
@@ -797,7 +797,7 @@ describe('find', (it) => {
     });
   });
 
-  it.describe('test with duplicate values for paginated field', (it) => {
+  it.describe('test with duplicate values for paginated field with', (it) => {
     it('should query first few pages with next/previous', async (t) => {
       const collection = t.context.db.collection('test_duplicate_custom_fields');
       // First page of 2
@@ -1099,7 +1099,7 @@ describe('find', (it) => {
   });
 
   it.describe('test with date as paginated field using dot notation', (it) => {
-    it('should query first few pages', async (t) => {
+    it('should query first few pages with next/previous', async (t) => {
       const collection = t.context.db.collection('test_paging_date_in_object');
       const paginatedField = 'start.date'; // Use dot notation in paginated field.
       const limit = 2;
@@ -1136,6 +1136,53 @@ describe('find', (it) => {
         limit,
         paginatedField,
         previous: res.previous
+      });
+
+      t.is(res.results.start, undefined); // Verify it is not returned since it is not requested.
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 3);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+    });
+
+    it('should query first few pages with after/before', async (t) => {
+      const collection = t.context.db.collection('test_paging_date_in_object');
+      const paginatedField = 'start.date'; // Use dot notation in paginated field.
+      const limit = 2;
+
+      // First page.
+      var res = await paging.find(collection, {
+        limit,
+        paginatedField,
+      });
+
+      t.is(res.results.start, undefined); // Verify it is not returned since it is not requested.
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 3);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward.
+      res = await paging.find(collection, {
+        limit,
+        paginatedField,
+        after: res.results[res.results.length -1]._id
+      });
+
+      t.is(res.results.start, undefined); // Verify it is not returned since it is not requested.
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 2);
+      t.is(res.results[1].counter, 1);
+      t.true(res.hasPrevious);
+      t.false(res.hasNext);
+
+      // Go backward
+      res = await paging.find(collection, {
+        limit,
+        paginatedField,
+        before: res.results[0]._id
       });
 
       t.is(res.results.start, undefined); // Verify it is not returned since it is not requested.

--- a/src/find.js
+++ b/src/find.js
@@ -59,8 +59,6 @@ module.exports = async function(collection, params) {
       );
       if (doc) {
         params.next = [doc[params.paginatedField], params.after];
-      } else {
-        params.next = null;
       }
     } else {
       params.next = params.after;
@@ -80,8 +78,6 @@ module.exports = async function(collection, params) {
       );
       if (doc) {
         params.previous = [doc[params.paginatedField], params.before];
-      } else {
-        params.previous = null;
       }
     } else {
       params.previous = params.before;

--- a/src/find.js
+++ b/src/find.js
@@ -57,6 +57,9 @@ module.exports = async function(collection, params) {
   // to fix this, we secondarily sort on _id, which is always unique.
   var shouldSecondarySortOnId = params.paginatedField !== '_id';
 
+  //
+  // params.after - overides params.next
+  //
   // The 'after' param sets the start position for the next page. This is similar to the
   // 'next' param, with the difference that 'after' takes a plain _id instead of an encoded
   // string of both _id and paginatedField values.
@@ -78,6 +81,9 @@ module.exports = async function(collection, params) {
     }
   }
 
+  //
+  // params.before - overides params.previous
+  //
   // The 'before' param sets the start position for the previous page. This is similar to the
   // 'previous' param, with the difference that 'before' takes a plain _id instead of an encoded
   // string of both _id and paginatedField values.

--- a/src/find.js
+++ b/src/find.js
@@ -57,6 +57,9 @@ module.exports = async function(collection, params) {
         { _id: params.after },
         { [params.paginatedField]: true, _id: false },
       );
+      if (! doc) {
+        throw new Error('pagination-cursor-does-not-exist');
+      }
       params.next = [doc[params.paginatedField], params.after];
     } else {
       params.next = params.after;
@@ -74,6 +77,9 @@ module.exports = async function(collection, params) {
         { _id: params.before },
         { [params.paginatedField]: true, _id: false },
       );
+      if (! doc) {
+        throw new Error('pagination-cursor-does-not-exist');
+      }
       params.previous = [doc[params.paginatedField], params.before];
     } else {
       params.previous = params.before;

--- a/src/find.js
+++ b/src/find.js
@@ -26,6 +26,17 @@ var bsonUrlEncoding = require('./utils/bsonUrlEncoding');
  *    -after {String} The _id to start querying the page.
  *    -before {String} The _id to start querying previous page.
  */
+
+function getPropertyViaDotNotation(propertyName, object) {
+  const parts = propertyName.split('.');
+
+  let prop = object;
+  for (let i=0; i < parts.length; i++) {
+    prop = prop[parts[i]];
+  }
+  return prop;
+}
+
 module.exports = async function(collection, params) {
   if (params.previous) params.previous = bsonUrlEncoding.decode(params.previous);
   if (params.next) params.next = bsonUrlEncoding.decode(params.next);
@@ -58,7 +69,9 @@ module.exports = async function(collection, params) {
         { [params.paginatedField]: true, _id: false },
       );
       if (doc) {
-        params.next = [doc[params.paginatedField], params.after];
+        // Handle usage of dot notation in paginatedField
+        const prop = getPropertyViaDotNotation(params.paginatedField, doc);
+        params.next = [prop, params.after];
       }
     } else {
       params.next = params.after;
@@ -77,7 +90,9 @@ module.exports = async function(collection, params) {
         { [params.paginatedField]: true, _id: false },
       );
       if (doc) {
-        params.previous = [doc[params.paginatedField], params.before];
+        // Handle usage of dot notation in paginatedField
+        const prop = getPropertyViaDotNotation(params.paginatedField, doc);
+        params.previous = [prop, params.before];
       }
     } else {
       params.previous = params.before;

--- a/src/find.js
+++ b/src/find.js
@@ -23,6 +23,8 @@ var bsonUrlEncoding = require('./utils/bsonUrlEncoding');
  *      The only reason to NOT use the Mongo _id field is if you chose to implement your own ids.
  *    -next {String} The value to start querying the page.
  *    -previous {String} The value to start querying previous page.
+ *    -after {String} The _id to start querying the page.
+ *    -before {String} The _id to start querying previous page.
  */
 module.exports = async function(collection, params) {
   if (params.previous) params.previous = bsonUrlEncoding.decode(params.previous);
@@ -43,6 +45,40 @@ module.exports = async function(collection, params) {
   // because then we can't exclusively use it for our range queries (that use $lt and $gt). So
   // to fix this, we secondarily sort on _id, which is always unique.
   var shouldSecondarySortOnId = params.paginatedField !== '_id';
+
+  // The 'after' param sets the start position for the next page. This is similar to the
+  // 'next' param, with the difference that 'after' takes a plain _id instead of an encoded
+  // string of both _id and paginatedField values.
+  if (params.after) {
+    if (shouldSecondarySortOnId) {
+      // Since the primary sort field is not provided by the 'after' pagination cursor we
+      // have to look it up when the paginated field is not _id.
+      const doc = await collection.findOne(
+        { _id: params.after },
+        { [params.paginatedField]: true, _id: false },
+      );
+      params.next = [doc[params.paginatedField], params.after];
+    } else {
+      params.next = params.after;
+    }
+  }
+
+  // The 'before' param sets the start position for the previous page. This is similar to the
+  // 'previous' param, with the difference that 'before' takes a plain _id instead of an encoded
+  // string of both _id and paginatedField values.
+  if (params.before) {
+    if (shouldSecondarySortOnId) {
+      // Since the primary sort field is not provided by the 'before' pagination cursor we
+      // have to look it up when the paginated field is not _id.
+      const doc = await collection.findOne(
+        { _id: params.before },
+        { [params.paginatedField]: true, _id: false },
+      );
+      params.previous = [doc[params.paginatedField], params.before];
+    } else {
+      params.previous = params.before;
+    }
+  }
 
   var fields;
   var removePaginatedFieldInResponse = false;

--- a/src/find.js
+++ b/src/find.js
@@ -57,10 +57,11 @@ module.exports = async function(collection, params) {
         { _id: params.after },
         { [params.paginatedField]: true, _id: false },
       );
-      if (! doc) {
-        throw new Error('pagination-cursor-does-not-exist');
+      if (doc) {
+        params.next = [doc[params.paginatedField], params.after];
+      } else {
+        params.next = null;
       }
-      params.next = [doc[params.paginatedField], params.after];
     } else {
       params.next = params.after;
     }
@@ -77,10 +78,11 @@ module.exports = async function(collection, params) {
         { _id: params.before },
         { [params.paginatedField]: true, _id: false },
       );
-      if (! doc) {
-        throw new Error('pagination-cursor-does-not-exist');
+      if (doc) {
+        params.previous = [doc[params.paginatedField], params.before];
+      } else {
+        params.previous = null;
       }
-      params.previous = [doc[params.paginatedField], params.before];
     } else {
       params.previous = params.before;
     }


### PR DESCRIPTION
This PR adds two new params `before` and `after`.

These are used just as `next` and `previous`, with the difference that they take a document `_id` instead of a hashed version of `_id` + `paginationFieldValue`, like `next` and `previous` do.

This allows for pagination by _id even when the pagination field is not the _id. It comes at the price of an extra DB lookup, but allows for a shorter page cursor.

I’ll be updating the docs and unit tests but I first wanted to check your stance to merging this feature.

Thoughts?

NOTE: This PR was branched from my other PR so that change is also included in the diff (at the bottom of the file). I'll get the other PR ready to be merged before this one, to remedy that.