### PR TITLE
updated base64-url to 2.2.0 to address vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -947,9 +947,9 @@
       "dev": true
     },
     "base64-url": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.3.tgz",
-      "integrity": "sha1-+LbFN/CaT8WMmcuG4LDpxhRhog8="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.0.tgz",
+      "integrity": "sha512-Y4qHHAE+rWjmAFPQmHPiiD+hWwM/XvuFLlP6kVxlwZJK7rjiE2uIQR9tZ37iEr1E6iCj9799yxMAmiXzITb3lQ=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/mixmaxhq/mongo-cursor-pagination#readme",
   "dependencies": {
-    "base64-url": "^1.3.2",
+    "base64-url": "^2.2.0",
     "mongodb-extended-json": "^1.7.1",
     "object-path": "^0.11.4",
     "projection-utils": "^1.1.0",


### PR DESCRIPTION
Addresses vulnerability https://nodesecurity.io/advisories/660, and issue#32.