### PR TITLE
Aggregate support

### DIFF
--- a/spec/aggregateSpec.js
+++ b/spec/aggregateSpec.js
@@ -1,0 +1,579 @@
+const { describe } = require('ava-spec');
+const test = require('ava');
+const paging = require('../');
+const dbUtils = require('./support/db');
+
+const driver = process.env.DRIVER;
+
+let mongod;
+test.before('start mongo server', async () => {
+  mongod = dbUtils.start();
+  const db = await dbUtils.db(mongod, driver);
+
+  // Set up collections once for testing later.
+  await Promise.all([
+    db.collection('test_paging').insert([{
+      counter: 1
+    }, {
+      counter: 2
+    }, {
+      counter: 3
+    }, {
+      counter: 4,
+      color: 'blue'
+    }, {
+      counter: 5,
+      color: 'blue'
+    }, {
+      counter: 6,
+      color: 'blue'
+    }, {
+      counter: 7,
+      color: 'blue'
+    }, {
+      counter: 8,
+      color: 'blue'
+    }]),
+    db.collection('test_aggregation').insert([{
+      items: [1,2,3]
+    }, {
+      items: [4,5,6]
+    }, {
+      items: [1,3,6]
+    }, {
+      items: [2,4,5]
+    }]),
+    db.collection('test_aggregation_lookup').insert([{
+      _id: 1,
+      name: 'mercury'
+    }, {
+      _id: 2,
+      name: 'venus'
+    }, {
+      _id: 3,
+      name: 'earth'
+    }, {
+      _id: 4,
+      name: 'mars'
+    }, {
+      _id: 5,
+      name: 'jupiter'
+    }, {
+      _id: 6,
+      name: 'saturn'
+    }])
+  ]);
+});
+
+describe('aggregate', (it) => {
+  it.beforeEach(async (t) => {
+    t.context.db = await dbUtils.db(mongod, driver);
+  });
+
+  it.describe('test pagination', (it) => {
+    it('should query first few pages with next/previous', async (t) => {
+      const collection = t.context.db.collection('test_paging');
+      // First page of 3
+      let res = await paging.aggregate(collection, {
+        limit: 3
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 8);
+      t.is(res.results[1].counter, 7);
+      t.is(res.results[2].counter, 6);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 3
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        next: res.next
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 5);
+      t.is(res.results[1].counter, 4);
+      t.is(res.results[2].counter, 3);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward another 3
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        next: res.next
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 2);
+      t.is(res.results[1].counter, 1);
+      t.true(res.hasPrevious);
+      t.false(res.hasNext);
+
+      // Now back up 3
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        previous: res.previous
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 5);
+      t.is(res.results[1].counter, 4);
+      t.is(res.results[2].counter, 3);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Now back up 3 more
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        previous: res.previous
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 8);
+      t.is(res.results[1].counter, 7);
+      t.is(res.results[2].counter, 6);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+    });
+
+    it('should query first few pages with after/before', async (t) => {
+      const collection = t.context.db.collection('test_paging');
+      // First page of 3
+      let res = await paging.aggregate(collection, {
+        limit: 3
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 8);
+      t.is(res.results[1].counter, 7);
+      t.is(res.results[2].counter, 6);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 3
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        after: res.results[res.results.length -1]._id
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 5);
+      t.is(res.results[1].counter, 4);
+      t.is(res.results[2].counter, 3);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward another 3
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        after: res.results[res.results.length -1]._id
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 2);
+      t.is(res.results[1].counter, 1);
+      t.true(res.hasPrevious);
+      t.false(res.hasNext);
+
+      // Now back up 3
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        before: res.results[0]._id
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 5);
+      t.is(res.results[1].counter, 4);
+      t.is(res.results[2].counter, 3);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Now back up 3 more
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        before: res.results[0]._id
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 8);
+      t.is(res.results[1].counter, 7);
+      t.is(res.results[2].counter, 6);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+    });
+
+    it('should handle hitting the end with next/previous', async (t) => {
+      const collection = t.context.db.collection('test_paging');
+      // First page of 2
+      var res = await paging.aggregate(collection, {
+        limit: 4
+      });
+
+      t.is(res.results.length, 4);
+      t.is(res.results[0].counter, 8);
+      t.is(res.results[1].counter, 7);
+      t.is(res.results[2].counter, 6);
+      t.is(res.results[3].counter, 5);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 2
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        next: res.next
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 3);
+      t.is(res.results[2].counter, 2);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward another 1, results should be empty.
+      res = await paging.aggregate(collection, {
+        limit: 2,
+        next: res.next
+      });
+
+      t.is(res.results.length, 1);
+      t.is(res.results[0].counter, 1);
+      t.true(res.hasPrevious);
+      t.false(res.hasNext);
+    });
+
+    it('should handle hitting the end with after/before', async (t) => {
+      const collection = t.context.db.collection('test_paging');
+      // First page of 2
+      var res = await paging.aggregate(collection, {
+        limit: 4
+      });
+
+      t.is(res.results.length, 4);
+      t.is(res.results[0].counter, 8);
+      t.is(res.results[1].counter, 7);
+      t.is(res.results[2].counter, 6);
+      t.is(res.results[3].counter, 5);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 2
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        after: res.results[res.results.length -1]._id
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 3);
+      t.is(res.results[2].counter, 2);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward another 1, results should be empty.
+      res = await paging.aggregate(collection, {
+        limit: 2,
+        after: res.results[res.results.length -1]._id
+      });
+
+      t.is(res.results.length, 1);
+      t.is(res.results[0].counter, 1);
+      t.true(res.hasPrevious);
+      t.false(res.hasNext);
+    });
+
+    it('should handle hitting the beginning with next/previous', async (t) => {
+      const collection = t.context.db.collection('test_paging');
+      // First page of 2
+      var res = await paging.aggregate(collection, {
+        limit: 4
+      });
+
+      t.is(res.results.length, 4);
+      t.is(res.results[0].counter, 8);
+      t.is(res.results[1].counter, 7);
+      t.is(res.results[2].counter, 6);
+      t.is(res.results[3].counter, 5);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 2
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        next: res.next
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 3);
+      t.is(res.results[2].counter, 2);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go back to beginning.
+      res = await paging.aggregate(collection, {
+        limit: 100,
+        previous: res.previous
+      });
+
+      t.is(res.results.length, 4);
+      t.is(res.results[0].counter, 8);
+      t.is(res.results[1].counter, 7);
+      t.is(res.results[2].counter, 6);
+      t.is(res.results[3].counter, 5);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+    });
+
+    it('should handle hitting the beginning with after/before', async (t) => {
+      const collection = t.context.db.collection('test_paging');
+      // First page of 2
+      var res = await paging.aggregate(collection, {
+        limit: 4
+      });
+
+      t.is(res.results.length, 4);
+      t.is(res.results[0].counter, 8);
+      t.is(res.results[1].counter, 7);
+      t.is(res.results[2].counter, 6);
+      t.is(res.results[3].counter, 5);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 2
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        after: res.results[res.results.length -1]._id
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 3);
+      t.is(res.results[2].counter, 2);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go back to beginning.
+      res = await paging.aggregate(collection, {
+        limit: 100,
+        before: res.results[0]._id
+      });
+
+      t.is(res.results.length, 4);
+      t.is(res.results[0].counter, 8);
+      t.is(res.results[1].counter, 7);
+      t.is(res.results[2].counter, 6);
+      t.is(res.results[3].counter, 5);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+    });
+
+    it('should use passed-in simple aggregation', async (t) => {
+      const collection = t.context.db.collection('test_paging');
+      // First page.
+      var res = await paging.aggregate(collection, {
+        aggregation: [{
+          $match: { color: 'blue' }
+        }]
+      });
+
+      t.is(res.results.length, 5);
+      t.is(res.results[0].color, 'blue');
+      t.false(res.hasNext);
+      t.false(res.hasPrevious);
+    });
+
+    it('should not return "next" or "previous" if there are no results', async (t) => {
+      const collection = t.context.db.collection('test_paging');
+      // First page.
+      var res = await paging.aggregate(collection, {
+        limit: 3,
+        aggregation: [{
+          $match: { nonexistantfield: true }
+        }]
+      });
+
+      t.is(res.results.length, 0);
+      t.false(res.hasNext);
+      t.false(res.hasPrevious);
+    });
+
+    it('should respect sortAscending option with next/previous', async (t) => {
+      const collection = t.context.db.collection('test_paging');
+      // First page of 3
+      var res = await paging.aggregate(collection, {
+        limit: 3,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 1);
+      t.is(res.results[1].counter, 2);
+      t.is(res.results[2].counter, 3);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 3
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        next: res.next,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 5);
+      t.is(res.results[2].counter, 6);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward another 3
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        next: res.next,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 7);
+      t.is(res.results[1].counter, 8);
+      t.true(res.hasPrevious);
+      t.false(res.hasNext);
+
+      // // Now back up 3
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        previous: res.previous,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 5);
+      t.is(res.results[2].counter, 6);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Now back up 3 more
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        previous: res.previous,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 1);
+      t.is(res.results[1].counter, 2);
+      t.is(res.results[2].counter, 3);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+    });
+
+    it('should respect sortAscending option with after/before', async (t) => {
+      const collection = t.context.db.collection('test_paging');
+      // First page of 3
+      var res = await paging.aggregate(collection, {
+        limit: 3,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 1);
+      t.is(res.results[1].counter, 2);
+      t.is(res.results[2].counter, 3);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward 3
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        after: res.results[res.results.length -1]._id,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 5);
+      t.is(res.results[2].counter, 6);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Go forward another 3
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        after: res.results[res.results.length -1]._id,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 2);
+      t.is(res.results[0].counter, 7);
+      t.is(res.results[1].counter, 8);
+      t.true(res.hasPrevious);
+      t.false(res.hasNext);
+
+      // // Now back up 3
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        before: res.results[0]._id,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 4);
+      t.is(res.results[1].counter, 5);
+      t.is(res.results[2].counter, 6);
+      t.true(res.hasPrevious);
+      t.true(res.hasNext);
+
+      // Now back up 3 more
+      res = await paging.aggregate(collection, {
+        limit: 3,
+        before: res.results[0]._id,
+        sortAscending: true
+      });
+
+      t.is(res.results.length, 3);
+      t.is(res.results[0].counter, 1);
+      t.is(res.results[1].counter, 2);
+      t.is(res.results[2].counter, 3);
+      t.false(res.hasPrevious);
+      t.true(res.hasNext);
+    });
+  });
+
+  it.describe('lookup aggregations', (it) => {
+    it('return expected results from aggregation', async (t) => {
+      const collection = t.context.db.collection('test_aggregation');
+
+      const res = await paging.aggregate(collection, {
+        aggregation: [{
+          $match: {
+            items: 5
+          }
+        }, {
+          $unwind: '$items'
+        }, {
+          $lookup: {
+            from: 'test_aggregation_lookup',
+            localField: 'items',
+            foreignField: '_id',
+            as: 'itemDoc'
+          }
+        }, {
+          $unwind: '$itemDoc'
+        }, {
+          $group: {
+            _id: '$_id',
+            planets: { $push: '$itemDoc.name' }
+          }
+        }],
+        limit: 1
+      });
+
+      t.is(res.results.length, 1);
+      t.deepEqual(res.results[0].planets, ['mars', 'jupiter', 'saturn']);
+      t.true(res.hasNext);
+    });
+  });
+});

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -1,0 +1,69 @@
+const _ = require('underscore');
+const sanitizeParams = require('./utils/sanitizeParams');
+const { prepareResponse, generateSort, generateCursorQuery } = require('./utils/query');
+
+/**
+ * Performs an aggregate() query on a passed-in Mongo collection, using criteria you specify.
+ * Unlike `find()`, this method requires fine tuning by the user, and must comply with the following
+ * two criteria so that the pagination magic can work properly.
+ *
+ * 1. `aggregate()` will insert a `$sort` and `$limit` clauses in your aggregation pipeline immediately after
+ * the first $match is found. Consider this while building your pipeline.
+ *
+ * 2. The documents resulting from the aggregation _must_ contain the paginated fields so that a
+ * cursor can be built from the result set.
+ *
+ * Additionally, an additional query will be appended to the first `$match` found in order to apply the offset
+ * required for the cursor.
+ *
+ * @param {MongoCollection} collection A collection object returned from the MongoDB library's
+ *    or the mongoist package's `db.collection(<collectionName>)` method.
+ * @param {Object} params
+ *    -aggregation {Object[]} The aggregation query.
+ *    -limit {Number} The page size. Must be between 1 and `config.MAX_LIMIT`.
+ *    -paginatedField {String} The field name to query the range for. The field must be:
+ *        1. Orderable. We must sort by this value. If duplicate values for paginatedField field
+ *          exist, the results will be secondarily ordered by the _id.
+ *        2. Indexed. For large collections, this should be indexed for query performance.
+ *        3. Immutable. If the value changes between paged queries, it could appear twice.
+ *      The default is to use the Mongo built-in '_id' field, which satisfies the above criteria.
+ *      The only reason to NOT use the Mongo _id field is if you chose to implement your own ids.
+ *    -next {String} The value to start querying the page.
+ *    -previous {String} The value to start querying previous page.
+ *    -after {String} The _id to start querying the page.
+ *    -before {String} The _id to start querying previous page.
+ */
+module.exports = async function aggregate(collection, params) {
+  params = _.defaults(
+    await sanitizeParams(collection, params),
+    { aggregation: [] }
+  );
+  let cursorQuery = generateCursorQuery(params);
+  let $sort = generateSort(params);
+  
+  let index = _.findIndex(params.aggregation, ((step) => !_.isEmpty(step.$match)));
+
+  if (index < 0) {
+    params.aggregation.unshift({ $match: cursorQuery });
+    index = 0;
+  } else {
+    const matchStep = params.aggregation[index];
+
+    params.aggregation[index] = {
+      $match: {
+        $and: [cursorQuery, matchStep.$match]
+      }
+    };
+  }
+
+  params.aggregation.splice(index + 1, 0, { $sort });
+  params.aggregation.splice(index + 2, 0, { $limit: params.limit + 1 });
+
+  // Support both the native 'mongodb' driver and 'mongoist'. See:
+  // https://www.npmjs.com/package/mongoist#cursor-operations
+  const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor': 'aggregate';
+
+  let results = await collection[aggregateMethod](params.aggregation).toArray();
+
+  return prepareResponse(results, params);
+};

--- a/src/find.js
+++ b/src/find.js
@@ -1,7 +1,6 @@
-var _ = require('underscore');
-var objectPath = require('object-path');
-var config = require('./config');
-var bsonUrlEncoding = require('./utils/bsonUrlEncoding');
+const _ = require('underscore');
+const sanitizeParams = require('./utils/sanitizeParams');
+const { prepareResponse, generateSort, generateCursorQuery } = require('./utils/query');
 
 /**
  * Performs a find() query on a passed-in Mongo collection, using criteria you specify. The results
@@ -26,207 +25,26 @@ var bsonUrlEncoding = require('./utils/bsonUrlEncoding');
  *    -after {String} The _id to start querying the page.
  *    -before {String} The _id to start querying previous page.
  */
-
-function getPropertyViaDotNotation(propertyName, object) {
-  const parts = propertyName.split('.');
-
-  let prop = object;
-  for (let i=0; i < parts.length; i++) {
-    prop = prop[parts[i]];
-  }
-  return prop;
-}
-
 module.exports = async function(collection, params) {
-  if (params.previous) params.previous = bsonUrlEncoding.decode(params.previous);
-  if (params.next) params.next = bsonUrlEncoding.decode(params.next);
+  const removePaginatedFieldInResponse = params.fields && !params.fields[params.paginatedField];
 
-  params = _.defaults(params, {
-    query: {},
-    limit: config.DEFAULT_LIMIT,
-    paginatedField: '_id'
-  });
-
-  var queries = [params.query];
-
-  if (params.limit < 1) params.limit = 1;
-  if (params.limit > config.MAX_LIMIT) params.limit = config.MAX_LIMIT;
-
-  // If the paginated field is not _id, then it might have duplicate values in it. This is bad
-  // because then we can't exclusively use it for our range queries (that use $lt and $gt). So
-  // to fix this, we secondarily sort on _id, which is always unique.
-  var shouldSecondarySortOnId = params.paginatedField !== '_id';
-
-  //
-  // params.after - overides params.next
-  //
-  // The 'after' param sets the start position for the next page. This is similar to the
-  // 'next' param, with the difference that 'after' takes a plain _id instead of an encoded
-  // string of both _id and paginatedField values.
-  if (params.after) {
-    if (shouldSecondarySortOnId) {
-      // Since the primary sort field is not provided by the 'after' pagination cursor we
-      // have to look it up when the paginated field is not _id.
-      const doc = await collection.findOne(
-        { _id: params.after },
-        { [params.paginatedField]: true, _id: false },
-      );
-      if (doc) {
-        // Handle usage of dot notation in paginatedField
-        const prop = getPropertyViaDotNotation(params.paginatedField, doc);
-        params.next = [prop, params.after];
-      }
-    } else {
-      params.next = params.after;
-    }
-  }
-
-  //
-  // params.before - overides params.previous
-  //
-  // The 'before' param sets the start position for the previous page. This is similar to the
-  // 'previous' param, with the difference that 'before' takes a plain _id instead of an encoded
-  // string of both _id and paginatedField values.
-  if (params.before) {
-    if (shouldSecondarySortOnId) {
-      // Since the primary sort field is not provided by the 'before' pagination cursor we
-      // have to look it up when the paginated field is not _id.
-      const doc = await collection.findOne(
-        { _id: params.before },
-        { [params.paginatedField]: true, _id: false },
-      );
-      if (doc) {
-        // Handle usage of dot notation in paginatedField
-        const prop = getPropertyViaDotNotation(params.paginatedField, doc);
-        params.previous = [prop, params.before];
-      }
-    } else {
-      params.previous = params.before;
-    }
-  }
-
-  var fields;
-  var removePaginatedFieldInResponse = false;
-
-  // The query must always include the paginatedField so we can construct the cursor.
-  if (params.fields) {
-    fields = _.extend({
-      _id: 0 // Mongo includes this field by default, so don't request it unless the user wants it.
-    }, params.fields);
-
-    if (!fields[params.paginatedField]) {
-      fields[params.paginatedField] = 1;
-      removePaginatedFieldInResponse = true;
-    }
-  }
-
-  var sortAsc = (!params.sortAscending && params.previous) || (params.sortAscending && !params.previous);
-  var comparisonOp = sortAsc ? '$gt' : '$lt';
-
-  if (params.next) {
-    if (shouldSecondarySortOnId) {
-      queries.push({
-        $or: [{
-          [params.paginatedField]: {
-            [comparisonOp]: params.next[0]
-          }
-        }, {
-          [params.paginatedField]: {
-            $eq: params.next[0]
-          },
-          _id: {
-            [comparisonOp]: params.next[1]
-          }
-        }]
-      });
-    } else {
-      queries.push({
-        [params.paginatedField]: {
-          [comparisonOp]: params.next
-        }
-      });
-    }
-  } else if (params.previous) {
-    if (shouldSecondarySortOnId) {
-      queries.push({
-        $or: [{
-          [params.paginatedField]: {
-            [comparisonOp]: params.previous[0]
-          }
-        }, {
-          [params.paginatedField]: {
-            $eq: params.previous[0]
-          },
-          _id: {
-            [comparisonOp]: params.previous[1]
-          }
-        }]
-      });
-    } else {
-      queries.push({
-        [params.paginatedField]: {
-          [comparisonOp]: params.previous
-        }
-      });
-    }
-  }
-
-  var sortDir = sortAsc ? 1 : -1;
-  var sort;
-  if (shouldSecondarySortOnId) {
-    sort = {
-      [params.paginatedField]: sortDir,
-      _id: sortDir
-    };
-  } else {
-    sort = {
-      [params.paginatedField]: sortDir
-    };
-  }
+  params = _.defaults(
+    await sanitizeParams(collection, params),
+    { query: {} }
+  );
+  const cursorQuery = generateCursorQuery(params);
+  const $sort = generateSort(params);
 
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations
-  var findMethod = collection.findAsCursor ? 'findAsCursor': 'find';
+  const findMethod = collection.findAsCursor ? 'findAsCursor': 'find';
 
-  var results = await collection[findMethod]({ $and: queries }, fields)
-    .sort(sort)
+  const results = await collection[findMethod]({ $and: [cursorQuery, params.query] }, params.fields)
+    .sort($sort)
     .limit(params.limit + 1) // Query one more element to see if there's another page.
     .toArray();
 
-  var hasMore = results.length > params.limit;
-  // Remove the extra element that we added to 'peek' to see if there were more entries.
-  if (hasMore) results.pop();
-
-  var hasPrevious = !!params.next || !!(params.previous && hasMore);
-  var hasNext = !!params.previous || hasMore;
-
-  // If we sorted reverse to get the previous page, correct the sort order.
-  if (params.previous) results = results.reverse();
-
-  var response = {
-    results,
-    previous: results[0],
-    hasPrevious,
-    next: results[results.length - 1],
-    hasNext
-  };
-
-  if (response.previous) {
-    var previousPaginatedField = objectPath.get(response.previous, params.paginatedField);
-    if (shouldSecondarySortOnId) {
-      response.previous = bsonUrlEncoding.encode([previousPaginatedField, response.previous._id]);
-    } else {
-      response.previous = bsonUrlEncoding.encode(previousPaginatedField);
-    }
-  }
-  if (response.next) {
-    var nextPaginatedField = objectPath.get(response.next, params.paginatedField);
-    if (shouldSecondarySortOnId) {
-      response.next = bsonUrlEncoding.encode([nextPaginatedField, response.next._id]);
-    } else {
-      response.next = bsonUrlEncoding.encode(nextPaginatedField);
-    }
-  }
+  const response = prepareResponse(results, params);
 
   // Remove fields that we added to the query (such as paginatedField and _id) that the user didn't ask for.
   if (removePaginatedFieldInResponse) {

--- a/src/findWithReq.js
+++ b/src/findWithReq.js
@@ -1,44 +1,12 @@
 var find = require('./find');
-var resolveFields = require('./utils/resolveFields');
-var _ = require('underscore');
-
-/**
- * Normalize the given query parameter to an array, so we support both param=a,b and
- * param[]=a&param[]=b.
- *
- * @param {Object} query The parsed query object containing the given parameter.
- * @param {String} param The parameter to normalize.
- * @returns {String[]} The normalized array from the given query parameter.
- * @throws {TypeError} When the query parameter isn't a string, an empty value, or an array of
- *   strings.
- */
-function normalizeQueryArray(query, param) {
-  const value = query[param];
-  if (Array.isArray(value)) {
-    for (let i = 0; i < value.length; ++i) {
-      if (!_.isString(value[i])) {
-        throw new TypeError('expected string array or comma-separated string for ' + param);
-      }
-    }
-    return value;
-  }
-  // This goes before _.isString so we don't split an empty string into ['']. The array option just
-  // uses whatever the user provides.
-  if (_.isEmpty(value)) {
-    return [];
-  }
-  if (_.isString(value)) {
-    return value.split(',');
-  }
-  throw new TypeError('expected string array or comma-separated string for ' + param);
-}
+var sanitizeQuery = require('./utils/sanitizeQuery');
 
 /**
  * A wrapper around `find()` that make it easy to implement a basic HTTP API using Express. So your
  * user can call "/list?limit=1&fields=_id,name" and the querystring parameters will be passed
  * to this method on the Express request object.
  *
- * @params {ExpressRequest} req An express request object with the following on the querystring:
+ * @param {ExpressRequest} req An express request object with the following on the querystring:
  *    -limit: If a numeric string, passed to `find()` as the limit. If limit also passed in params
  *      then this value cannot exceed it.
  *    -next: If a non-empty string, passed to `find()` as the next cursor.
@@ -46,41 +14,15 @@ function normalizeQueryArray(query, param) {
  *    -fields: If a non-empty string, used to limit fields that are returned. Multiple fields
  *      can be specified as a comma-delimited list. If field name used is not in params.fields,
  *      it will be ignored.
- * @params {MongoCollection} collection A collection object returned from the MongoDB library's
+ * @param {MongoCollection} collection A collection object returned from the MongoDB library's
  *    or the mongoist package's `db.collection(<collectionName>)` method.
  * @param {Object} params See documentation for `find()`, plus these options:
  *    -overrideFields: an object containing fields that should override fields from the querystring, e.g.
  *      {_id: 0} or {internalField: 1}. We only support field exclusion for _id, as we expect whitelists
  *      for fields from both params.fields and params.overrideFields.
  */
-module.exports = async function(req, collection, params) {
-  params = params || {};
-
-  if (!_.isEmpty(req.query.limit)) {
-    var limit = parseInt(req.query.limit);
-    // Don't let the user specify a higher limit than params.limit, if defined.
-    if (!isNaN(limit) && (!params.limit || params.limit > limit)) {
-      params.limit = limit;
-    }
-  }
-
-  if (!_.isEmpty(req.query.next)) {
-    params.next = req.query.next;
-  }
-
-  if (!_.isEmpty(req.query.previous)) {
-    params.previous = req.query.previous;
-  }
-
-  // Don't trust fields passed in the querystring, so whitelist them against the fields defined in
-  // parameters.
-  const fields = resolveFields(normalizeQueryArray(req.query, 'fields'), params.fields, params.overrideFields);
-  if (fields === null) {
-    throw new TypeError('no valid fields provided');
-  }
-
-  // Set fields to undefined if it's empty to avoid adding _id: 0 in find.
-  params.fields = _.isEmpty(fields) ? undefined : fields;
+module.exports = async function findWithReq(req, collection, params) {
+  params = sanitizeQuery(req.query, params);
 
   return find(collection, params);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,17 @@
 var config = require('./config');
+var aggregate = require('./aggregate');
 var find = require('./find');
 var findWithReq = require('./findWithReq');
 var search = require('./search');
+var sanitizeQuery = require('./utils/sanitizeQuery');
 var mongoosePlugin = require('./mongoose.plugin');
 
 module.exports = {
   config,
   find,
   findWithReq,
+  aggregate,
   search,
-  mongoosePlugin
+  mongoosePlugin,
+  sanitizeQuery
 };

--- a/src/utils/getPropertyViaDotNotation.js
+++ b/src/utils/getPropertyViaDotNotation.js
@@ -1,0 +1,9 @@
+module.exports = function getPropertyViaDotNotation(propertyName, object) {
+  const parts = propertyName.split('.');
+
+  let prop = object;
+  for (let i=0; i < parts.length; i++) {
+    prop = prop[parts[i]];
+  }
+  return prop;
+};

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -1,0 +1,118 @@
+const bsonUrlEncoding = require('./bsonUrlEncoding');
+const objectPath = require('object-path');
+
+module.exports = {
+  /**
+   * Parses the raw results from a find or aggregate query and generates a response object that
+   * contain the various pagination properties
+   *
+   * @param {Object[]} results the results from a query
+   * @param {Object} params The params originally passed to `find` or `aggregate`
+   *
+   * @return {Object} The object containing pagination properties
+   */
+  prepareResponse(results, params) {
+    const hasMore = results.length > params.limit;
+    const shouldSecondarySortOnId = params.paginatedField !== '_id';
+    // Remove the extra element that we added to 'peek' to see if there were more entries.
+    if (hasMore) results.pop();
+
+    const hasPrevious = !!params.next || !!(params.previous && hasMore);
+    const hasNext = !!params.previous || hasMore;
+
+    // If we sorted reverse to get the previous page, correct the sort order.
+    if (params.previous) results = results.reverse();
+
+    const response = {
+      results,
+      previous: results[0],
+      hasPrevious,
+      next: results[results.length - 1],
+      hasNext
+    };
+
+    if (response.previous) {
+      const previousPaginatedField = objectPath.get(response.previous, params.paginatedField);
+      if (shouldSecondarySortOnId) {
+        response.previous = bsonUrlEncoding.encode([previousPaginatedField, response.previous._id]);
+      } else {
+        response.previous = bsonUrlEncoding.encode(previousPaginatedField);
+      }
+    }
+    if (response.next) {
+      const nextPaginatedField = objectPath.get(response.next, params.paginatedField);
+      if (shouldSecondarySortOnId) {
+        response.next = bsonUrlEncoding.encode([nextPaginatedField, response.next._id]);
+      } else {
+        response.next = bsonUrlEncoding.encode(nextPaginatedField);
+      }
+    }
+
+    return response;
+  },
+
+  /**
+   * Generates a `$sort` object given the parameters
+   *
+   * @param {Object} params The params originally passed to `find` or `aggregate`
+   *
+   * @return {Object} a sort object 
+   */
+  generateSort(params) {
+    const sortAsc = (!params.sortAscending && params.previous) || (params.sortAscending && !params.previous);
+    const sortDir = sortAsc ? 1 : -1;
+    const shouldSecondarySortOnId = params.paginatedField !== '_id';
+
+    if (shouldSecondarySortOnId) {
+      return {
+        [params.paginatedField]: sortDir,
+        _id: sortDir
+      };
+    }
+
+    return {
+      [params.paginatedField]: sortDir
+    };
+  },
+
+  /**
+   * Generates a cursor query that provides the offset capabilities
+   *
+   * @param {Object} params The params originally passed to `find` or `aggregate`
+   *
+   * @return {Object} a cursor offset query
+   */
+  generateCursorQuery(params) {
+    if (!params.next && !params.previous) return {};
+
+    const sortAsc = (!params.sortAscending && params.previous) || (params.sortAscending && !params.previous);
+    const comparisonOp = sortAsc ? '$gt' : '$lt';
+    const shouldSecondarySortOnId = params.paginatedField !== '_id';
+
+    // a `next` cursor will have precedence over a `previous` cursor.
+    const op = params.next || params.previous;
+
+    if (shouldSecondarySortOnId) {
+      return {
+        $or: [{
+          [params.paginatedField]: {
+            [comparisonOp]: op[0]
+          }
+        }, {
+          [params.paginatedField]: {
+            $eq: op[0]
+          },
+          _id: {
+            [comparisonOp]: op[1]
+          }
+        }]
+      };
+    }
+
+    return {
+      [params.paginatedField]: {
+        [comparisonOp]: op
+      }
+    };
+  }
+};

--- a/src/utils/sanitizeParams.js
+++ b/src/utils/sanitizeParams.js
@@ -1,0 +1,83 @@
+const _ = require('underscore');
+const bsonUrlEncoding = require('./bsonUrlEncoding');
+const getPropertyViaDotNotation = require('./getPropertyViaDotNotation');
+const config = require('../config');
+
+module.exports = async function sanitizeParams(collection, params) {
+  if (params.previous) params.previous = bsonUrlEncoding.decode(params.previous);
+  if (params.next) params.next = bsonUrlEncoding.decode(params.next);
+
+  params = _.defaults(params, {
+    limit: config.DEFAULT_LIMIT,
+    paginatedField: '_id'
+  });
+
+  if (params.limit < 1) params.limit = 1;
+  if (params.limit > config.MAX_LIMIT) params.limit = config.MAX_LIMIT;
+
+  // If the paginated field is not _id, then it might have duplicate values in it. This is bad
+  // because then we can't exclusively use it for our range queries (that use $lt and $gt). So
+  // to fix this, we secondarily sort on _id, which is always unique.
+  var shouldSecondarySortOnId = params.paginatedField !== '_id';
+
+  //
+  // params.after - overides params.next
+  //
+  // The 'after' param sets the start position for the next page. This is similar to the
+  // 'next' param, with the difference that 'after' takes a plain _id instead of an encoded
+  // string of both _id and paginatedField values.
+  if (params.after) {
+    if (shouldSecondarySortOnId) {
+      // Since the primary sort field is not provided by the 'after' pagination cursor we
+      // have to look it up when the paginated field is not _id.
+      const doc = await collection.findOne(
+        { _id: params.after },
+        { [params.paginatedField]: true, _id: false },
+      );
+      if (doc) {
+        // Handle usage of dot notation in paginatedField
+        const prop = getPropertyViaDotNotation(params.paginatedField, doc);
+        params.next = [prop, params.after];
+      }
+    } else {
+      params.next = params.after;
+    }
+  }
+
+  //
+  // params.before - overides params.previous
+  //
+  // The 'before' param sets the start position for the previous page. This is similar to the
+  // 'previous' param, with the difference that 'before' takes a plain _id instead of an encoded
+  // string of both _id and paginatedField values.
+  if (params.before) {
+    if (shouldSecondarySortOnId) {
+      // Since the primary sort field is not provided by the 'before' pagination cursor we
+      // have to look it up when the paginated field is not _id.
+      const doc = await collection.findOne(
+        { _id: params.before },
+        { [params.paginatedField]: true, _id: false },
+      );
+      if (doc) {
+        // Handle usage of dot notation in paginatedField
+        const prop = getPropertyViaDotNotation(params.paginatedField, doc);
+        params.previous = [prop, params.before];
+      }
+    } else {
+      params.previous = params.before;
+    }
+  }
+
+  // The query must always include the paginatedField so we can construct the cursor.
+  if (params.fields) {
+    params.fields = _.extend({
+      _id: 0 // Mongo includes this field by default, so don't request it unless the user wants it.
+    }, params.fields);
+
+    if (!params.fields[params.paginatedField]) {
+      params.fields[params.paginatedField] = 1;
+    }
+  }
+
+  return params;
+};

--- a/src/utils/sanitizeQuery.js
+++ b/src/utils/sanitizeQuery.js
@@ -1,0 +1,81 @@
+const _ = require('underscore');
+const resolveFields = require('./resolveFields');
+
+/**
+ * Normalize the given query parameter to an array, so we support both param=a,b and
+ * param[]=a&param[]=b.
+ *
+ * @param {Object} query The parsed query object containing the given parameter.
+ * @param {String} param The parameter to normalize.
+ * @returns {String[]} The normalized array from the given query parameter.
+ * @throws {TypeError} When the query parameter isn't a string, an empty value, or an array of
+ *   strings.
+ */
+function normalizeQueryArray(query, param) {
+  const value = query[param];
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; ++i) {
+      if (!_.isString(value[i])) {
+        throw new TypeError('expected string array or comma-separated string for ' + param);
+      }
+    }
+    return value;
+  }
+  // This goes before _.isString so we don't split an empty string into ['']. The array option just
+  // uses whatever the user provides.
+  if (_.isEmpty(value)) {
+    return [];
+  }
+  if (_.isString(value)) {
+    return value.split(',');
+  }
+  throw new TypeError('expected string array or comma-separated string for ' + param);
+}
+
+/**
+ * Sanitizes a `query` object received and merges it's changes to an optional `params` object
+ *
+ * @param {Object} query An object with the following properties:
+ *    -limit: If a numeric string, use it as the limit. If limit also passed in params
+ *      then this value cannot exceed it.
+ *    -next: If a non-empty string, use it as the next cursor.
+ *    -previous: If a non-empty string, use it as the previous cursor.
+ *    -fields: If a non-empty string, used to limit fields that are returned. Multiple fields
+ *      can be specified as a comma-delimited list. If field name used is not in params.fields,
+ *      it will be ignored.
+ * @param {Object} params See documentation for `find()`, plus these options:
+ *    -overrideFields: an object containing fields that should override fields from the querystring, e.g.
+ *      {_id: 0} or {internalField: 1}. We only support field exclusion for _id, as we expect whitelists
+ *      for fields from both params.fields and params.overrideFields.
+ */
+module.exports = function sanitizeQuery(query, params) {
+  params = params || {};
+
+  if (!_.isEmpty(query.limit)) {
+    var limit = parseInt(query.limit);
+    // Don't let the user specify a higher limit than params.limit, if defined.
+    if (!isNaN(limit) && (!params.limit || params.limit > limit)) {
+      params.limit = limit;
+    }
+  }
+
+  if (!_.isEmpty(query.next)) {
+    params.next = query.next;
+  }
+
+  if (!_.isEmpty(query.previous)) {
+    params.previous = query.previous;
+  }
+
+  // Don't trust fields passed in the querystring, so whitelist them against the fields defined in
+  // parameters.
+  const fields = resolveFields(normalizeQueryArray(query, 'fields'), params.fields, params.overrideFields);
+  if (fields === null) {
+    throw new TypeError('no valid fields provided');
+  }
+
+  // Set fields to undefined if it's empty to avoid adding _id: 0 in find.
+  params.fields = _.isEmpty(fields) ? undefined : fields;
+
+  return params;
+};


### PR DESCRIPTION
This PR introduces support for `aggregate`, it has some limitations on what can be done though so that pagination works as expected, but it covers a very common scenario: expanding subdocuments stored in separate collections, for example:

```
[
{ $match: { foo: 'bar' } },
{ $unwind: '$items' },
{ $lookup: { from: 'foo', as: 'itemDocs' }, // omiting properties for this example
{ $unwind: '$itemDocs },
{ $group: { _id: '$_id', items: { $push: '$itemDocs' } } }
]
```

Additionally I refactored a lot of the code in `find` and separated in granular functions making the code easier to understand and also makes it possible to share code between `aggregate` and `find`, also factored express request sanitization code to a standalone function so that this sanitization is available for client code.