### PR TITLE
Mongoose: Model.paginate() returns model instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2413,7 +2413,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2434,12 +2435,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2454,17 +2457,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2581,7 +2587,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2593,6 +2600,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2607,6 +2615,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2614,12 +2623,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2638,6 +2649,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2718,7 +2730,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2730,6 +2743,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2815,7 +2829,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2851,6 +2866,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2870,6 +2886,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2913,12 +2930,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2926,7 +2945,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "function-name-support": {
       "version": "0.2.0",
@@ -3117,6 +3137,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "function-bind": "^1.0.2"
       }
@@ -3388,7 +3409,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-ci": {
       "version": "1.1.0",
@@ -3851,9 +3873,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -4652,11 +4674,6 @@
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true,
       "optional": true
-    },
-    "object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
     },
     "object.omit": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   "homepage": "https://github.com/mixmaxhq/mongo-cursor-pagination#readme",
   "dependencies": {
     "base64-url": "^2.2.0",
+    "lodash": "^4.17.15",
     "mongodb-extended-json": "^1.7.1",
-    "object-path": "^0.11.4",
     "projection-utils": "^1.1.0",
     "semver": "^5.4.1",
     "underscore": "^1.8.3"

--- a/spec/mongoosePluginSpec.js
+++ b/spec/mongoosePluginSpec.js
@@ -67,4 +67,9 @@ describe('mongoose plugin', (it) => {
     t.is(data.hasOwnProperty('next'), true);
     t.is(data.hasOwnProperty('hasNext'), true);
   });
+
+  it('should return Mongoose documents', async function(t) {
+    let data = await Post.paginate();
+    t.is(data.results[0].schema, Post.schema);
+  });
 });

--- a/src/find.js
+++ b/src/find.js
@@ -39,10 +39,12 @@ module.exports = async function(collection, params) {
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const findMethod = collection.findAsCursor ? 'findAsCursor': 'find';
 
-  const results = await collection[findMethod]({ $and: [cursorQuery, params.query] }, params.fields)
+  const cursorOrQuery = collection[findMethod]({ $and: [cursorQuery, params.query] }, params.fields)
     .sort($sort)
     .limit(params.limit + 1) // Query one more element to see if there's another page.
-    .toArray();
+
+  // Support both MongoDB collections and Mongoose models.
+  const results = await (cursorOrQuery.toArray ? cursorOrQuery.toArray() : cursorOrQuery);
 
   const response = prepareResponse(results, params);
 

--- a/src/mongoose.plugin.js
+++ b/src/mongoose.plugin.js
@@ -1,4 +1,3 @@
-
 const find = require('./find');
 const _ = require('underscore');
 
@@ -16,19 +15,19 @@ module.exports = function (schema, options) {
    * @param {Object} param required parameter
    */
 
-  const fn = function(param) {
+  const paginate = function(param) {
     if (!this.collection) {
       throw new Error('collection property not found');
     }
 
     param = _.extend({}, param);
         
-    return find(this.collection, param);
+    return find(this, param);
   };
 
   if (options && options.name) {
-    schema.statics[options.name] = fn;
+    schema.statics[options.name] = paginate;
   } else {
-    schema.statics.paginate = fn;
+    schema.statics.paginate = paginate;
   }
 };

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -1,5 +1,5 @@
 const bsonUrlEncoding = require('./bsonUrlEncoding');
-const objectPath = require('object-path');
+const { get } = require('lodash');
 
 module.exports = {
   /**
@@ -32,7 +32,7 @@ module.exports = {
     };
 
     if (response.previous) {
-      const previousPaginatedField = objectPath.get(response.previous, params.paginatedField);
+      const previousPaginatedField = get(response.previous, params.paginatedField);
       if (shouldSecondarySortOnId) {
         response.previous = bsonUrlEncoding.encode([previousPaginatedField, response.previous._id]);
       } else {
@@ -40,7 +40,7 @@ module.exports = {
       }
     }
     if (response.next) {
-      const nextPaginatedField = objectPath.get(response.next, params.paginatedField);
+      const nextPaginatedField = get(response.next, params.paginatedField);
       if (shouldSecondarySortOnId) {
         response.next = bsonUrlEncoding.encode([nextPaginatedField, response.next._id]);
       } else {


### PR DESCRIPTION
Calling `paginate()` on a Mongoose model will return arrays of model instances as results (as opposed to POJOs).

This is really useful e.g. for GraphQL resolvers that call model methods; these currently have to employ workarounds like calling `new Model(item)` on each result to be able to do so.

It turned out that the `get()` method in object-path simply doesn't work on Mongoose instances, so I replaced it with lodash.