### PR TITLE
feat: support locale-based collations when sorting (MX-7704)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Changelog
 
+* 7.2.0 Add support for `COLLATION` configuration parameter.
+
 * 7.1.0 Add support for `aggregate`.
-	
+
 * 7.0.1 Update base64-url to fix security issue (https://github.com/mixmaxhq/mongo-cursor-pagination/pull/41 - thanks @pwiebe).
 
 * 7.0.0 Add findWithReq overrideFields support. Breaking: now throws errors on unusable `fields`/`overrideFields`, so check your inputs. Also changes our intersection mechanism, so it _could_ cause backwards-incompatible changes to fields resolution. If causes unexpected backwards-incompatible changes, please file an issue!

--- a/README.md
+++ b/README.md
@@ -299,6 +299,11 @@ router.get('/myobjects', async (req, res, next) => {
 
 If the `limit` parameter isn't passed, then this library will default to returning 50 results. This can be overridden by setting `mongoPaging.config.DEFAULT_LIMIT = <new default limit>;`. Regardless of the `limit` passed in, a maximum of 300 documents will be returned. This can be overridden by setting `mongoPaging.config.MAX_LIMIT = <new max limit>;`.
 
+### Alphabetical sorting
+
+The collation to use for alphabetical sorting, both with `find` and `aggregate`, can be selected by setting `mongoPaging.config.COLLATION`. If this parameter is
+not set, no collation will be provided for the aggregation/cursor, which means that MongoDB will use whatever collation was set for the collection.
+
 ### Indexes for sorting
 
 `mongo-cursor-pagination` uses `_id` as a secondary sorting field when providing a `paginatedField` property. It is recommended that you have an index for optimal performance. Example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2413,7 +2413,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2434,12 +2435,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2454,17 +2457,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2581,7 +2587,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2593,6 +2600,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2607,6 +2615,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2614,12 +2623,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2638,6 +2649,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2718,7 +2730,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2730,6 +2743,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2815,7 +2829,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2851,6 +2866,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2870,6 +2886,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2913,12 +2930,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2926,7 +2945,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "function-name-support": {
       "version": "0.2.0",
@@ -3117,6 +3137,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "function-bind": "^1.0.2"
       }
@@ -3388,7 +3409,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-ci": {
       "version": "1.1.0",
@@ -4018,6 +4040,13 @@
       "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
       "dev": true
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
+      "optional": true
+    },
     "meow": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -4443,12 +4472,42 @@
       }
     },
     "mongoist": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/mongoist/-/mongoist-1.4.3.tgz",
-      "integrity": "sha512-SQ3pPZKacRPgSp+iDD1jj+BrJvS+oVexRWw8x7qN68W6AfLcVnpflH1vN15/PEZLK5ga8QRIsTO7ttZsNndaLQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mongoist/-/mongoist-2.3.0.tgz",
+      "integrity": "sha512-bwz1b/F5zZs4hI7xkgGoxHhbl5GJ/QglksqrwXORKDuHHQVnU8KPQtTXDIMkyI8T0vg4t+MCAfiV9tzk5Ggc5g==",
       "dev": true,
       "requires": {
-        "mongodb": "^2.2.31"
+        "debug": "^4.1.1",
+        "mongodb": "^3.3.2"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
+          "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "mongodb": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.4.0.tgz",
+          "integrity": "sha512-W90jm/n8F0Edm47ljkVRK9l8qGW9g8T9ZSiZWRiUP58wLhsCJCeN/JxdpVnH0CUwwAw2hITUcCo9x58udpX2Uw==",
+          "dev": true,
+          "requires": {
+            "bson": "^1.1.1",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
+        }
       }
     },
     "mongoose": {
@@ -5497,6 +5556,16 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "seek-bzip": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
@@ -5623,6 +5692,16 @@
       "dev": true,
       "requires": {
         "source-map": "^0.5.6"
+      }
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
       }
     },
     "spawn-sync": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "mockgoose": "7.3.5",
     "mongodb": "^2.2.11",
     "mongodb-memory-server": "^1.6.1",
-    "mongoist": "1.4.3",
+    "mongoist": "2.3.0",
     "mongoose": "5.0.15"
   },
   "engines": {

--- a/spec/findSpec.js
+++ b/spec/findSpec.js
@@ -2,6 +2,7 @@ const { describe } = require('ava-spec');
 const test = require('ava');
 const paging = require('../');
 const dbUtils = require('./support/db');
+const _ = require('underscore');
 
 const driver = process.env.DRIVER;
 
@@ -116,6 +117,19 @@ test.before('start mongo server', async () => {
       counter: 2
     }, {
       counter: 1
+    }]),
+    db.collection('test_sorting').insert([{
+      name: 'Alpha'
+    }, {
+      name: 'gimel'
+    }, {
+      name: 'Beta'
+    }, {
+      name: 'bet'
+    }, {
+      name: 'Gamma'
+    }, {
+      name: 'aleph'
     }])
   ]);
 });
@@ -1191,6 +1205,30 @@ describe('find', (it) => {
       t.is(res.results[1].counter, 3);
       t.false(res.hasPrevious);
       t.true(res.hasNext);
+    });
+  });
+
+  it.describe('test alphabetical sorting', (it) => {
+    it('should query first few pages with next/previous', async (t) => {
+      const collection = t.context.db.collection('test_sorting');
+
+      const res = await paging.find(collection, {
+        paginatedField: 'name',
+        sortAscending: true,
+        limit: 10
+      });
+
+      t.deepEqual(_.pluck(res.results, 'name'), ['Alpha', 'Beta', 'Gamma', 'aleph', 'bet', 'gimel']);
+
+      paging.config.COLLATION = { locale: 'en' };
+
+      const res_localized = await paging.find(collection, {
+        paginatedField: 'name',
+        sortAscending: true,
+        limit: 10
+      });
+
+      t.deepEqual(_.pluck(res_localized.results, 'name'), ['aleph', 'Alpha', 'bet', 'Beta', 'Gamma', 'gimel']);
     });
   });
 });

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -1,6 +1,7 @@
 const _ = require('underscore');
 const sanitizeParams = require('./utils/sanitizeParams');
 const { prepareResponse, generateSort, generateCursorQuery } = require('./utils/query');
+const config = require('./config');
 
 /**
  * Performs an aggregate() query on a passed-in Mongo collection, using criteria you specify.
@@ -59,11 +60,13 @@ module.exports = async function aggregate(collection, params) {
   params.aggregation.splice(index + 1, 0, { $sort });
   params.aggregation.splice(index + 2, 0, { $limit: params.limit + 1 });
 
+  let options = config.COLLATION ? { collation: config.COLLATION } : undefined;
+
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor': 'aggregate';
 
-  let results = await collection[aggregateMethod](params.aggregation).toArray();
+  let results = await collection[aggregateMethod](params.aggregation, options).toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/find.js
+++ b/src/find.js
@@ -1,6 +1,7 @@
 const _ = require('underscore');
 const sanitizeParams = require('./utils/sanitizeParams');
 const { prepareResponse, generateSort, generateCursorQuery } = require('./utils/query');
+var config = require('./config');
 
 /**
  * Performs a find() query on a passed-in Mongo collection, using criteria you specify. The results
@@ -39,7 +40,9 @@ module.exports = async function(collection, params) {
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const findMethod = collection.findAsCursor ? 'findAsCursor': 'find';
 
-  const results = await collection[findMethod]({ $and: [cursorQuery, params.query] }, params.fields)
+  const query = collection[findMethod]({ $and: [cursorQuery, params.query] }, params.fields);
+  const collatedQuery = config.COLLATION ? query.collation(config.COLLATION) : query;
+  const results = await collatedQuery
     .sort($sort)
     .limit(params.limit + 1) // Query one more element to see if there's another page.
     .toArray();

--- a/src/find.js
+++ b/src/find.js
@@ -1,7 +1,7 @@
 const _ = require('underscore');
 const sanitizeParams = require('./utils/sanitizeParams');
 const { prepareResponse, generateSort, generateCursorQuery } = require('./utils/query');
-var config = require('./config');
+const config = require('./config');
 
 /**
  * Performs a find() query on a passed-in Mongo collection, using criteria you specify. The results


### PR DESCRIPTION
This allows sorting 'a' < 'B' < 'c' < 'D' instead of 'B' < 'D' < 'a' < 'c', or '2' < '9' < '10' instead of '10' < '2' < '9'  by configuring a collation to use for sorting (see https://docs.mongodb.com/manual/reference/collation/ ).