### PR TITLE
chore(ci): skip failing commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ci:commitlint": "commitlint-jenkins --pr-only",
     "lint": "eslint .",
     "prepublishOnly": "npm run babelBuild && if [ \"$CI\" = '' ]; then node -p 'JSON.parse(process.env.npm_package_config_manualPublishMessage)'; exit 1; fi",
-    "semantic-release": "semantic-release",
+    "semantic-release": "SEMANTIC_COMMITLINT_SKIP=5ed5489,e2ab709,187f1fe,0dcc73f semantic-release",
     "test": "DRIVER=mongoist jest && DRIVER=native jest"
   },
   "repository": {


### PR DESCRIPTION
#### Changes Made
The following commits fail commitlint:
```
5ed5489 Replace mongodb-extended-json with bson; Fix test
e2ab709 Exclude /dist from sublime project file.
187f1fe docs: document the interaction between collation settings and
index usage
0dcc73f Lose await in sample code of README
```

After verifying that they don't involve functional changes, we can skip
them to trigger a release when this PR is merged.

#### Potential Risks
the biggest risk is that one of these commits contains a breaking change and we have to publish a new version of the module.

#### Test Plan
ensure unit tests pass.

#### Checklist
- [ ] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
