### PR TITLE
fix(bson): fixes regression where string _ids were no longer supported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3990,9 +3990,9 @@
       }
     },
     "bson": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
-      "integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.1.0.tgz",
+      "integrity": "sha512-xwNzRRsK2xmHvHuPESi0zVfgsm4edO47WdulNaShTriunNUMRDOAlKwpJc8zpkOXczIzbxUD7kFzhUGVYoZLDw==",
       "requires": {
         "buffer": "^5.1.0",
         "long": "^4.0.0"
@@ -4004,9 +4004,9 @@
           "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
         },
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/mixmaxhq/mongo-cursor-pagination#readme",
   "dependencies": {
     "base64-url": "^2.2.0",
-    "bson": "^4.0.4",
+    "bson": "^4.1.0",
     "object-path": "^0.11.4",
     "projection-utils": "^1.1.0",
     "semver": "^5.4.1",

--- a/test/utils/bsonUrlEncoding.test.js
+++ b/test/utils/bsonUrlEncoding.test.js
@@ -33,4 +33,14 @@ describe('bson url encoding', () => {
     expect(typeof decoded.number).toEqual('number');
     expect(typeof decoded.string).toEqual('string');
   });
+
+  it('encodes and decodes strings', async () => {
+    const str = bsonUrlEncoding.encode('string _id');
+
+    expect(str).toEqual('InN0cmluZyBfaWQi');
+
+    const decoded = bsonUrlEncoding.decode(str);
+    expect(decoded).toEqual('string _id');
+    expect(typeof decoded).toEqual('string');
+  });
 });


### PR DESCRIPTION
#### Changes Made
Fixes https://github.com/mixmaxhq/mongo-cursor-pagination/issues/196

Fixes regression in #134 whereby in moving
from mongodb-extended-json to bson for encoding cursors, we accidentally broke support for string
_ids. This is because EJSON.stringify didn't support encoding strings. Support was added for it
in mongodb/js-bson#376 in v4.1.0.

#### Potential Risks
Low. This change is also backwards-compatible, even in the case that someone stored cursors generated by a previous version of this library, because it does not change how those are decoded.

#### Test Plan
I'm relying on the unit tests to ensure this doesn't regress functionality.

#### Checklist
- [x] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
