### PR TITLE
feat: increase MAX_LIMIT to allow larger page sizes

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,7 @@ module.exports = {
   /**
    * {Number} The maximum limit (page size).
    */
-  MAX_LIMIT: 300,
+  MAX_LIMIT: 5000,
 
   /**
    * {Number} The default limit (page size), if none is specified.


### PR DESCRIPTION
#### Changes Made
Increased the `MAX_LIMIT` value. @bradvogel tells me the original limit ([set in 2017](https://github.com/mixmaxhq/mongo-cursor-pagination/pull/14)) was somewhat arbitrary. Since Mongo can handle many more results per page, and some use-cases may benefit from it, this raises the limit substantially. A benefit is that with a larger page size, the code requires fewer round-trips to the server to fetch a large result set, which may result in better performance if networking is a bottleneck.

#### Potential Risks
Code that has been using a page size larger than the previous `MAX_LIMIT` will now return more results per page, which might be unexpected.

#### Test Plan
- [x] Unit tests pass
- [x] Tested by building and linking locally

#### Checklist
- [ ] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
