### PR TITLE
Allow for options to be applied to the collection

### DIFF
--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -74,7 +74,7 @@ module.exports = async function aggregate(collection, params) {
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
 
-  const results = await collection[aggregateMethod](params.aggregation, {...options, readPreference}).toArray();
+  const results = await collection[aggregateMethod](params.aggregation, {...options, read: readPreference}).toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -4,7 +4,7 @@ const { prepareResponse, generateSort, generateCursorQuery } = require('./utils/
 const config = require('./config');
 
 /**
- * Performs an aggregate() query on a passed-in Mongo collection, using criteria you specify.
+ * Performs an aggregate() query on a passed-in Mongo, using criteria you specify.
  * Unlike `find()`, this method requires fine tuning by the user, and must comply with the following
  * two criteria so that the pagination magic can work properly.
  *
@@ -68,13 +68,13 @@ module.exports = async function aggregate(collection, params) {
    * See mongo documentation: https://docs.mongodb.com/manual/reference/collation/#collation-and-index-use
    */
   const options = config.COLLATION ? { collation: config.COLLATION } : undefined;
-  const readPreference = options.readPref || 'primary';
+  const readPreference = params.readPref || 'primary';
 
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
 
-  const results = await collection[aggregateMethod](params.aggregation, options).readPref(readPreference).toArray();
+  const results = await collection[aggregateMethod](params.aggregation, {...options, readPreference}).toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -76,14 +76,10 @@ module.exports = async function aggregate(collection, params) {
       ...params.options,
     };
   }
-  console.log('params', params)
-  console.log('combinedOptions', options);
 
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
-  
-  console.log('collection[aggregateMethod](params.aggregation, options)', collection[aggregateMethod](params.aggregation, options));
   
   const results = await collection[aggregateMethod](params.aggregation, options).toArray();
 

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -76,7 +76,7 @@ module.exports = async function aggregate(collection, params) {
       ...params.options,
     };
   }
-  
+  console.log('params', params)
   console.log('combinedOptions', options);
 
   // Support both the native 'mongodb' driver and 'mongoist'. See:

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -74,7 +74,7 @@ module.exports = async function aggregate(collection, params) {
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
 
-  const results = await collection[aggregateMethod](params.aggregation, {...options, read: readPreference}).toArray();
+  const results = await collection[aggregateMethod](params.aggregation, options).read(readPreference).toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -68,13 +68,13 @@ module.exports = async function aggregate(collection, params) {
    * See mongo documentation: https://docs.mongodb.com/manual/reference/collation/#collation-and-index-use
    */
   const options = config.COLLATION ? { collation: config.COLLATION } : undefined;
-  //const readPreference = params.readPref || 'primary';
+  const readPreference = params.readPref || 'primary';
 
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
 
-  const results = await collection[aggregateMethod](params.aggregation, options).toArray();
+  const results = await collection[aggregateMethod](params.aggregation, {...options, read: readPreference}).toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -74,8 +74,7 @@ module.exports = async function aggregate(collection, params) {
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
   
-  console.log('foobar', collection[aggregateMethod](params.aggregation, options));
-  const results = await collection[aggregateMethod](params.aggregation, options).read('secondaryPreferred').toArray();
+  const results = await collection[aggregateMethod](params.aggregation, { ...options, readPreference }).read('secondaryPreferred').toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -68,13 +68,13 @@ module.exports = async function aggregate(collection, params) {
    * See mongo documentation: https://docs.mongodb.com/manual/reference/collation/#collation-and-index-use
    */
   const options = config.COLLATION ? { collation: config.COLLATION } : undefined;
-  const readPreference = params.readPref || 'primary';
+  //const readPreference = params.readPref || 'primary';
 
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
 
-  const results = await collection[aggregateMethod](params.aggregation, {...options, read: readPreference}).toArray();
+  const results = await collection[aggregateMethod](params.aggregation, options).toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -83,7 +83,7 @@ module.exports = async function aggregate(collection, params) {
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
   
-  console.log('collection[aggregateMethod](params.aggregation, options)', collection[aggregateMethod](params.aggregation, { ...options, readPreference }));
+  console.log('collection[aggregateMethod](params.aggregation, options)', collection[aggregateMethod](params.aggregation, options));
   
   const results = await collection[aggregateMethod](params.aggregation, options).toArray();
 

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -4,7 +4,7 @@ const { prepareResponse, generateSort, generateCursorQuery } = require('./utils/
 const config = require('./config');
 
 /**
- * Performs an aggregate() query on a passed-in Mongo, using criteria you specify.
+ * Performs an aggregate() query on a passed-in Mongo collection, using criteria you specify.
  * Unlike `find()`, this method requires fine tuning by the user, and must comply with the following
  * two criteria so that the pagination magic can work properly.
  *

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -33,6 +33,7 @@ const config = require('./config');
  *    -previous {String} The value to start querying previous page.
  *    -after {String} The _id to start querying the page.
  *    -before {String} The _id to start querying previous page.
+ *    -readPref {String} the MongoDB readPref (https://docs.mongodb.com/manual/core/read-preference/) 
  */
 module.exports = async function aggregate(collection, params) {
   params = _.defaults(await sanitizeParams(collection, params), { aggregation: [] });
@@ -67,12 +68,13 @@ module.exports = async function aggregate(collection, params) {
    * See mongo documentation: https://docs.mongodb.com/manual/reference/collation/#collation-and-index-use
    */
   const options = config.COLLATION ? { collation: config.COLLATION } : undefined;
+  const readPreference = options.readPref || 'primary';
 
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
 
-  const results = await collection[aggregateMethod](params.aggregation, options).toArray();
+  const results = await collection[aggregateMethod](params.aggregation, options).readPref(readPreference).toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -74,7 +74,8 @@ module.exports = async function aggregate(collection, params) {
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
   
-  const results = await collection.read(readPreference)[aggregateMethod](params.aggregation, options).toArray();
+  console.log('foobar', collection[aggregateMethod](params.aggregation, options));
+  const results = await collection[aggregateMethod](params.aggregation, options).toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -74,7 +74,7 @@ module.exports = async function aggregate(collection, params) {
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
 
-  const results = await collection[aggregateMethod](params.aggregation, options).read(readPreference).toArray();
+  const results = await collection[aggregateMethod](params.aggregation, options).readPref(readPreference).toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -75,6 +75,8 @@ module.exports = async function aggregate(collection, params) {
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
   
+  console.log('collection[aggregateMethod](params.aggregation, { ...options, readPreference })', collection[aggregateMethod](params.aggregation, { ...options, readPreference }));
+  
   const results = await collection[aggregateMethod](params.aggregation, { ...options, readPreference }).toArray();
 
   return prepareResponse(results, params);

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -75,7 +75,7 @@ module.exports = async function aggregate(collection, params) {
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
   
-  const results = await collection[aggregateMethod](params.aggregation, { ...options, readPreference }).read('secondaryPreferred').toArray();
+  const results = await collection[aggregateMethod](params.aggregation, { ...options, readPreference }).toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -69,6 +69,7 @@ module.exports = async function aggregate(collection, params) {
    */
   const options = config.COLLATION ? { collation: config.COLLATION } : undefined;
   const readPreference = params.readPref || 'primary';
+  console.log('combinedOptions', { ...options, readPreference });
 
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -75,7 +75,7 @@ module.exports = async function aggregate(collection, params) {
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
   
   console.log('foobar', collection[aggregateMethod](params.aggregation, options));
-  const results = await collection[aggregateMethod](params.aggregation, options).toArray();
+  const results = await collection[aggregateMethod](params.aggregation, options).read('secondaryPreferred').toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -73,8 +73,8 @@ module.exports = async function aggregate(collection, params) {
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
-
-  const results = await collection[aggregateMethod](params.aggregation, options).readPref(readPreference).toArray();
+  
+  const results = await collection.read(readPreference)[aggregateMethod](params.aggregation, options).toArray();
 
   return prepareResponse(results, params);
 };


### PR DESCRIPTION
#### Changes Made
Support for passing in an `options` object param allowing for options beyond just collation to be set on an aggregation.  The missing feature here that I needed was readPreference. 
```
options: {
  readPreference: 'secondaryPreferred',
}
```

#### Potential Risks
None I'm aware of as it will not have any effect on the use without the new feature.

#### Test Plan
- Run queries without passing in a new readPreference and confirm things still function correctly, and that the default readPref is applied.
- Run queries with options: `{ readPreference: 'secondaryPreferred' }` specified and confirm the readPref is properly applied.
 
#### Checklist
- [ ] I've increased test coverage
- [ ] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
