### PR TITLE
fix: skip bad commit message

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ci:commitlint": "commitlint-jenkins --pr-only",
     "lint": "eslint .",
     "prepublishOnly": "npm run babelBuild && if [ \"$CI\" = '' ]; then node -p 'JSON.parse(process.env.npm_package_config_manualPublishMessage)'; exit 1; fi",
-    "semantic-release": "SEMANTIC_COMMITLINT_SKIP=5ed5489,e2ab709,187f1fe,0dcc73f semantic-release",
+    "semantic-release": "SEMANTIC_COMMITLINT_SKIP=5ed5489,e2ab709,187f1fe,0dcc73f,6d15fe5 semantic-release",
     "test": "DRIVER=mongoist jest && DRIVER=native jest"
   },
   "repository": {


### PR DESCRIPTION
#### Changes Made
Jenkins wasn't reporting CI status in PR https://github.com/mixmaxhq/mongo-cursor-pagination/pull/289 and rather than debug the issue, I used my admin permissions to override it :(. This wasn't good because Jenkins was actually failing the build due to a bad commit message.

Low. This just skips a commit with an improper (unsemantic) commit message. Merging this should build a release of mongo-cursor pagination.

#### Potential Risks
Low. No code change.

#### Test Plan
None.
