### PR TITLE
feat: add support for aggregation `hint`s

### DIFF
--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -33,6 +33,7 @@ const config = require('./config');
  *    -previous {String} The value to start querying previous page.
  *    -after {String} The _id to start querying the page.
  *    -before {String} The _id to start querying previous page.
+ *    -options {Object} Aggregation options
  */
 module.exports = async function aggregate(collection, params) {
   params = _.defaults(await sanitizeParams(collection, params), { aggregation: [] });
@@ -57,6 +58,10 @@ module.exports = async function aggregate(collection, params) {
   params.aggregation.splice(index + 1, 0, { $sort });
   params.aggregation.splice(index + 2, 0, { $limit: params.limit + 1 });
 
+  // Aggregation options:
+  // https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#aggregate
+  // https://mongodb.github.io/node-mongodb-native/4.0/interfaces/aggregateoptions.html
+  const options = params.options || {};
   /**
    * IMPORTANT
    *
@@ -66,7 +71,7 @@ module.exports = async function aggregate(collection, params) {
    *
    * See mongo documentation: https://docs.mongodb.com/manual/reference/collation/#collation-and-index-use
    */
-  const options = config.COLLATION ? { collation: config.COLLATION } : undefined;
+  if (config.COLLATION) options.collation = config.COLLATION;
 
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -85,6 +85,14 @@ describe('aggregate', () => {
           name: 'saturn',
         },
       ]),
+      t.db.collection('test_aggregation_lookup').ensureIndex(
+        {
+          name: 'text',
+        },
+        {
+          name: 'test_index',
+        }
+      ),
       t.db.collection('test_aggregation_sort').insert([
         {
           name: 'Alpha',
@@ -666,6 +674,35 @@ describe('aggregate', () => {
         'Gamma',
         'gimel',
       ]);
+    });
+  });
+
+  describe('aggregation options', () => {
+    let spy;
+    beforeEach(() => {
+      spy = jest.spyOn(paging, 'aggregate');
+    });
+
+    afterEach(() => {
+      spy.mockRestore();
+    });
+
+    it('invokes aggregate with a `hint` if one is passed in via params object', async () => {
+      const collection = t.db.collection('test_aggregation_lookup');
+
+      await paging.aggregate(collection, {
+        aggregation: [
+          {
+            $sort: { name: 1 },
+          },
+        ],
+        hint: 'test_index',
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ hint: 'test_index' })
+      );
     });
   });
 });


### PR DESCRIPTION
#### Changes Made

This module supports `hint`s for `find` queries, and this commit adds logic to
support `hint`s for `aggregation`s.

#### Potential Risks
<!--- What can go wrong with this change? How will these changes affect adjacent code/features? How will we handle any adverse issues? --->

None perceived; both `mongoist` and the official node driver support this option.

#### Test Plan
<!--- How do we know this PR does what it's supposed to do? How do we ensure that adjacent code/features are still working? How do we evaluate the performance implications of this PR?--->

- [x] unit tests.
- [x] link to a module/service and manually test.

#### Checklist
- [x] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
