### PR TITLE
bump object-path to latest version due to security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "base64-url": "^2.2.0",
     "bson": "^4.1.0",
-    "object-path": "^0.11.5",
+    "object-path": "^0.11.8",
     "projection-utils": "^1.1.0",
     "semver": "^5.4.1",
     "underscore": "^1.9.2"


### PR DESCRIPTION

version 0.11.8 contains several security fixes:

Fix a prototype pollution vulnerability in the del(), empty(), push(), insert() functions when using the "inherited props" mode (e.g. when a new object-path instance is created with the includeInheritedProps option set to true or when using the withInheritedProps default instance. To help with preventing this type of vulnerability in the client code, also the get() function will now throw an exception if an object's magic properties are accessed. The vulnerability does not exist in the default instance exposed by object path (e.g objectPath.del()) if using version >= 0.11.0

version should be bumped and package-lock updated