### PR TITLE
fix: return _id when paginatedField is not set

### DIFF
--- a/src/find.js
+++ b/src/find.js
@@ -28,7 +28,8 @@ const config = require('./config');
  *    -hint {String} An optional index hint to provide to the mongo query
  */
 module.exports = async function(collection, params) {
-  const removePaginatedFieldInResponse = params.fields && !params.fields[params.paginatedField];
+  // Need to repeat `params.paginatedField` default value ('_id') since it's set in 'sanitizeParams()'
+  const removePaginatedFieldInResponse = params.fields && !params.fields[params.paginatedField || '_id'];
 
   params = _.defaults(await sanitizeParams(collection, params), { query: {} });
   const cursorQuery = generateCursorQuery(params);

--- a/src/find.js
+++ b/src/find.js
@@ -29,7 +29,8 @@ const config = require('./config');
  */
 module.exports = async function(collection, params) {
   // Need to repeat `params.paginatedField` default value ('_id') since it's set in 'sanitizeParams()'
-  const removePaginatedFieldInResponse = params.fields && !params.fields[params.paginatedField || '_id'];
+  const removePaginatedFieldInResponse =
+    params.fields && !params.fields[params.paginatedField || '_id'];
 
   params = _.defaults(await sanitizeParams(collection, params), { query: {} });
   const cursorQuery = generateCursorQuery(params);

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -1083,6 +1083,7 @@ describe('find', () => {
 
         expect(res.results.length).toEqual(5);
         expect(res.results[0].color).toBeFalsy();
+        expect(res.results[0]._id).not.toBeFalsy();
       });
 
       it('does not return "next" or "previous" if there are no results', async () => {


### PR DESCRIPTION
When `paginatedField` is not present, we were not returning
the _id field, even when it was specified to be returned.

resolves #309

#### Changes Made
* return `_id` when paginatedField is not set

#### Test Plan
- [X] Added unit testing around this

#### Checklist
- [X] I've increased test coverage
- [X] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
