### PR TITLE
feature(aggregate): added support for 2 additional use-cases while ma…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-cursor-pagination",
-  "version": "7.6.1",
+  "version": "7.7.0",
   "description": "Make it easy to return cursor-paginated results from a Mongo collection",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
#### Changes Made
Added new optional param to aggregate function to support more use-cases
1. undefined => preserve legacy behavior
2. null => allow data pre-transformation/summarization prior to pagination
3. custom user function => allow data post-transformation server-side)

#### Potential Risks
<!--- What can go wrong with this change? How will these changes affect adjacent code/features? How will we handle any adverse issues? --->

The assumptions in usage scenario 1 are the same as for 2. In both cases, there's still room for user error, if the user does not consider the established assumptions adequately.
The 3rd scenario can lead to even more user errors since the user must be aware that he may be providing additional steps to the pipeline after the pagination operations and as such must take into consideration any prior data transformations. Ultimately, in this scenario, the user could even override the $sort assumption so only advanced users should use it.

#### Test Plan
<!--- How do we know this PR does what it's supposed to do? How do we ensure that adjacent code/features are still working? How do we evaluate the performance implications of this PR?--->
The performance implications are directly related with the pipeline data transformation/summarization steps prior to the pagination steps and those that follow for both scenarios 2) and 3) respectively

#### Checklist
- [ ] I've increased test coverage

Sorry but at this time I don't have the time to add any additional meaningful tests for the new sample use cases. The changes are "minimal" and I'm convinced that added usefulness at this point suffice to justify this addition even though the additional tests could be helpful even if to explain the use cases better with practical examples.
I've attested though that all previous tests still succeed.

- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.