### PR TITLE
added aggregation field to the end

### DIFF
--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -55,8 +55,8 @@ module.exports = async function aggregate(collection, params) {
     };
   }
 
-  params.aggregation.splice(index + 1, 0, { $sort });
-  params.aggregation.splice(index + 2, 0, { $limit: params.limit + 1 });
+  params.aggregation.push({ $sort });
+  params.aggregation.push({ $limit: params.limit + 1 });
 
   // Aggregation options:
   // https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#aggregate


### PR DESCRIPTION
#### Changes Made
Currently, sort and limits are added at the next index of $match. This leads to other operations in the pipeline applied after the limit query giving wrong results. This change ensures that the sort and limit queries are applied in the end. 

Ref: Issue #317 

#### Potential Risks
No risks

#### Test Plan
Change is straightforward. I have also tested it with one of my projects

#### Checklist
- [ ] I've increased test coverage
- [X] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments or this PR.
