### PR TITLE
feat: allow collation as arg on find and aggregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,11 +329,33 @@ not set, no collation will be provided for the aggregation/cursor, which means t
 
 ## Important note regarding collation
 
-If using a global collation setting, ensure that your collections' indexes (that index upon string fields)
+If using a global collation setting, or a query with collation argument, ensure that your collections' indexes (that index upon string fields)
 have been created with the same collation option; if this isn't the case, your queries will be unable to
 take advantage of any indexes.
 
 See mongo documentation: https://docs.mongodb.com/manual/reference/collation/#collation-and-index-use
+
+For instance, given the following index:
+
+```js
+db.people.createIndex({ city: 1, _id: 1 });
+```
+
+When executing the query:
+
+```js
+MongoPaging.find(db.people, {
+  limit: 25,
+  paginatedField: 'city'
+  collation: { locale: 'en' },
+});
+```
+
+The index won't be used for the query because it doesn't include the collation used. The index should added as such:
+
+```js
+db.people.createIndex({ city: 1, _id: 1 }, { collation: { locale: 'en' } });
+```
 
 ### Indexes for sorting
 
@@ -354,7 +376,7 @@ MongoPaging.find(db.people, {
 For the above query to be optimal, you should have an index like:
 
 ```js
-db.people.ensureIndex({
+db.people.createIndex({
   name: 1,
   city: 1,
   _id: 1,

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -34,7 +34,7 @@ const config = require('./config');
  *    -after {String} The _id to start querying the page.
  *    -before {String} The _id to start querying previous page.
  *    -options {Object} Aggregation options
- *    -collation {Object} An optional collation to provide to the mongo query. E.g. { locale: 'en', strength: 2 }
+ *    -collation {Object} An optional collation to provide to the mongo query. E.g. { locale: 'en', strength: 2 }. When null, disables the global collation.
  */
 module.exports = async function aggregate(collection, params) {
   params = _.defaults(await sanitizeParams(collection, params), { aggregation: [] });
@@ -66,14 +66,12 @@ module.exports = async function aggregate(collection, params) {
   /**
    * IMPORTANT
    *
-   * If using a global collation setting, ensure that your collections' indexes (that index upon string fields)
-   * have been created with the same collation option; if this isn't the case, your queries will be unable to
-   * take advantage of any indexes.
-   *
-   * See mongo documentation: https://docs.mongodb.com/manual/reference/collation/#collation-and-index-use
+   * If using collation, check the README:
+   * https://github.com/mixmaxhq/mongo-cursor-pagination#important-note-regarding-collation
    */
+  const isCollationNull = params.collation === null;
   const collation = params.collation || config.COLLATION;
-  if (collation) options.collation = collation;
+  if (collation && !isCollationNull) options.collation = collation;
 
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -34,6 +34,7 @@ const config = require('./config');
  *    -after {String} The _id to start querying the page.
  *    -before {String} The _id to start querying previous page.
  *    -options {Object} Aggregation options
+ *    -collation {Object} An optional collation to provide to the mongo query. E.g. { locale: 'en', strength: 2 }
  */
 module.exports = async function aggregate(collection, params) {
   params = _.defaults(await sanitizeParams(collection, params), { aggregation: [] });
@@ -71,7 +72,8 @@ module.exports = async function aggregate(collection, params) {
    *
    * See mongo documentation: https://docs.mongodb.com/manual/reference/collation/#collation-and-index-use
    */
-  if (config.COLLATION) options.collation = config.COLLATION;
+  const collation = params.collation || config.COLLATION;
+  if (collation) options.collation = collation;
 
   // Support both the native 'mongodb' driver and 'mongoist'. See:
   // https://www.npmjs.com/package/mongoist#cursor-operations

--- a/src/find.js
+++ b/src/find.js
@@ -26,6 +26,7 @@ const config = require('./config');
  *    -after {String} The _id to start querying the page.
  *    -before {String} The _id to start querying previous page.
  *    -hint {String} An optional index hint to provide to the mongo query
+ *    -collation {Object} An optional collation to provide to the mongo query. E.g. { locale: 'en', strength: 2 }
  */
 module.exports = async function(collection, params) {
   // Need to repeat `params.paginatedField` default value ('_id') since it's set in 'sanitizeParams()'
@@ -51,7 +52,8 @@ module.exports = async function(collection, params) {
    *
    * See mongo documentation: https://docs.mongodb.com/manual/reference/collation/#collation-and-index-use
    */
-  const collatedQuery = config.COLLATION ? query.collation(config.COLLATION) : query;
+  const collation = params.collation || config.COLLATION;
+  const collatedQuery = collation ? query.collation(collation) : query;
   // Query one more element to see if there's another page.
   const cursor = collatedQuery.sort($sort).limit(params.limit + 1);
   if (params.hint) cursor.hint(params.hint);

--- a/src/find.js
+++ b/src/find.js
@@ -26,7 +26,7 @@ const config = require('./config');
  *    -after {String} The _id to start querying the page.
  *    -before {String} The _id to start querying previous page.
  *    -hint {String} An optional index hint to provide to the mongo query
- *    -collation {Object} An optional collation to provide to the mongo query. E.g. { locale: 'en', strength: 2 }
+ *    -collation {Object} An optional collation to provide to the mongo query. E.g. { locale: 'en', strength: 2 }. When null, disables the global collation.
  */
 module.exports = async function(collection, params) {
   // Need to repeat `params.paginatedField` default value ('_id') since it's set in 'sanitizeParams()'
@@ -46,14 +46,12 @@ module.exports = async function(collection, params) {
   /**
    * IMPORTANT
    *
-   * If using a global collation setting, ensure that your collections' indexes (that index upon string fields)
-   * have been created with the same collation option; if this isn't the case, your queries will be unable to
-   * take advantage of any indexes.
-   *
-   * See mongo documentation: https://docs.mongodb.com/manual/reference/collation/#collation-and-index-use
+   * If using collation, check the README:
+   * https://github.com/mixmaxhq/mongo-cursor-pagination#important-note-regarding-collation
    */
+  const isCollationNull = params.collation === null;
   const collation = params.collation || config.COLLATION;
-  const collatedQuery = collation ? query.collation(collation) : query;
+  const collatedQuery = collation && !isCollationNull ? query.collation(collation) : query;
   // Query one more element to see if there's another page.
   const cursor = collatedQuery.sort($sort).limit(params.limit + 1);
   if (params.hint) cursor.hint(params.hint);

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -647,8 +647,6 @@ describe('aggregate', () => {
         ],
       });
 
-      paging.config.COLLATION = { locale: 'en' };
-
       expect(_.pluck(res.results, 'name')).toEqual([
         'Alpha',
         'Beta',
@@ -664,9 +662,29 @@ describe('aggregate', () => {
             $sort: { name: 1 },
           },
         ],
+        collation: { locale: 'en' },
       });
 
       expect(_.pluck(res_localized.results, 'name')).toEqual([
+        'aleph',
+        'Alpha',
+        'bet',
+        'Beta',
+        'Gamma',
+        'gimel',
+      ]);
+
+      paging.config.COLLATION = { locale: 'en' };
+
+      const res_static_localized = await paging.aggregate(collection, {
+        aggregation: [
+          {
+            $sort: { name: 1 },
+          },
+        ],
+      });
+
+      expect(_.pluck(res_static_localized.results, 'name')).toEqual([
         'aleph',
         'Alpha',
         'bet',

--- a/test/aggregate.test.js
+++ b/test/aggregate.test.js
@@ -692,6 +692,22 @@ describe('aggregate', () => {
         'Gamma',
         'gimel',
       ]);
+
+      const res_excluding_collation = await paging.aggregate(collection, {
+        paginatedField: 'name',
+        sortAscending: true,
+        limit: 10,
+        collation: null,
+      });
+
+      expect(_.pluck(res_excluding_collation.results, 'name')).toEqual([
+        'Alpha',
+        'Beta',
+        'Gamma',
+        'aleph',
+        'bet',
+        'gimel',
+      ]);
     });
   });
 

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -1873,6 +1873,22 @@ describe('find', () => {
         'Gamma',
         'gimel',
       ]);
+
+      const res_excluding_collation = await paging.find(collection, {
+        paginatedField: 'name',
+        sortAscending: true,
+        limit: 10,
+        collation: null,
+      });
+
+      expect(_.pluck(res_excluding_collation.results, 'name')).toEqual([
+        'Alpha',
+        'Beta',
+        'Gamma',
+        'aleph',
+        'bet',
+        'gimel',
+      ]);
     });
   });
 

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -1841,15 +1841,31 @@ describe('find', () => {
         'gimel',
       ]);
 
+      const res_localized = await paging.find(collection, {
+        paginatedField: 'name',
+        sortAscending: true,
+        limit: 10,
+        collation: { locale: 'en' },
+      });
+
+      expect(_.pluck(res_localized.results, 'name')).toEqual([
+        'aleph',
+        'Alpha',
+        'bet',
+        'Beta',
+        'Gamma',
+        'gimel',
+      ]);
+
       paging.config.COLLATION = { locale: 'en' };
 
-      const res_localized = await paging.find(collection, {
+      const res_static_localized = await paging.find(collection, {
         paginatedField: 'name',
         sortAscending: true,
         limit: 10,
       });
 
-      expect(_.pluck(res_localized.results, 'name')).toEqual([
+      expect(_.pluck(res_static_localized.results, 'name')).toEqual([
         'aleph',
         'Alpha',
         'bet',


### PR DESCRIPTION
#### Changes Made

Enable the use of a custom collation for a single `find` or `aggregate` call.

Why: Using the default `config.COLLATION` means we must re-index the collections to ensure our indexes match the collation. Conversely, we could use the static configuration for a single call but it opens a breach for race-condition issues:

```js
paging.config.COLLATION = { locale: 'en' };
const results = await paging.find(collection, { ... })
// if any other `.find` or `.aggregate` methods were called before the `delete` line below,
// they will use the collation set above, which may not be desired;
delete paging.config.COLLATION;
```

With the PRs code, we can use:

```js
const results = await paging.find(collection, { ..., collation: { locale: 'en' } })
```

#### Potential Risks
<!--- What can go wrong with this change? How will these changes affect adjacent code/features? How will we handle any adverse issues? --->

- None. Adds capabilities.

#### Test Plan
<!--- How do we know this PR does what it's supposed to do? How do we ensure that adjacent code/features are still working? How do we evaluate the performance implications of this PR?--->

#### Checklist
- [x] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
