### PR TITLE
fix: skip commit with wrong scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ci:commitlint": "commitlint-jenkins --pr-only",
     "lint": "eslint .",
     "prepublishOnly": "npm run babelBuild && if [ \"$CI\" = '' ]; then node -p 'JSON.parse(process.env.npm_package_config_manualPublishMessage)'; exit 1; fi",
-    "semantic-release": "SEMANTIC_COMMITLINT_SKIP=5ed5489,e2ab709,187f1fe,0dcc73f,6d15fe5 semantic-release",
+    "semantic-release": "SEMANTIC_COMMITLINT_SKIP=5ed5489,e2ab709,187f1fe,0dcc73f,6d15fe5,7a05f30 semantic-release",
     "test": "DRIVER=mongoist jest && DRIVER=native jest"
   },
   "repository": {


### PR DESCRIPTION
#### Changes Made

The latest PR (https://github.com/mixmaxhq/mongo-cursor-pagination/pull/320), was merged with the "merge" strategy. This caused the commit https://github.com/mixmaxhq/mongo-cursor-pagination/commit/7a05f30859f03b1381957ce25358ecc4b9ce362d inside the PR to be added on Master, and that caused the CI to fail:

![image](https://user-images.githubusercontent.com/11169832/184901380-0997b986-3229-47c0-856a-e8025b7f048b.png)

In this PR, I'm adding the failing commit to the skip list, according to the guideline: https://github.com/mixmaxhq/semantic-commitlint#skip-commits

This repo already has the `ci:commitlint` [script](https://github.com/mixmaxhq/mongo-cursor-pagination/blob/b6d34a9658a9840324e76c7113b5fa54655967e8/package.json#L15) but it is always called with the "squash and merge" approach.
To prevent the issue from happening again, I'm disabling the "merge" strategy, and leaving only the "squash and merge" one.
WIth that, the `ci:commitlint` script will use the current PR name as the commit name.

#### Potential Risks
<!--- What can go wrong with this change? How will these changes affect adjacent code/features? How will we handle any adverse issues? --->

When clicking the "squash and merge" button, Github allows to change the commit name. If that is made during that step, the release can fail on master again. Ideally, we should be using the "merge" strategy for semantic release, but [commitlint-jenkins](https://github.com/mixmaxhq/commitlint-jenkins) doesn't seem to support this option.

#### Test Plan
<!--- How do we know this PR does what it's supposed to do? How do we ensure that adjacent code/features are still working? How do we evaluate the performance implications of this PR?--->

#### Checklist
- [ ] I've increased test coverage -> Not applicable
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
