### PR TITLE
feat: add a `sortCaseInsensitive` option to `find` and `aggregate`

### DIFF
--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -25,10 +25,14 @@ const config = require('./config');
  *    -paginatedField {String} The field name to query the range for. The field must be:
  *        1. Orderable. We must sort by this value. If duplicate values for paginatedField field
  *          exist, the results will be secondarily ordered by the _id.
- *        2. Indexed. For large collections, this should be indexed for query performance.
+ *        2. Indexed. If the aggregation pipieline can return a large number of documents, this should
+ *          be indexed for query performance.
  *        3. Immutable. If the value changes between paged queries, it could appear twice.
  *      The default is to use the Mongo built-in '_id' field, which satisfies the above criteria.
  *      The only reason to NOT use the Mongo _id field is if you chose to implement your own ids.
+ *    -sortAscending {boolean} Whether to sort in ascending order by the `paginatedField`.
+ *    -sortCaseInsensitive {boolean} Whether to ignore case when sorting, in which case `paginatedField`
+ *      must be a string property.
  *    -next {String} The value to start querying the page.
  *    -previous {String} The value to start querying previous page.
  *    -after {String} The _id to start querying the page.
@@ -38,31 +42,29 @@ const config = require('./config');
  */
 module.exports = async function aggregate(collection, params) {
   params = _.defaults(await sanitizeParams(collection, params), { aggregation: [] });
-  const cursorQuery = generateCursorQuery(params);
+
+  const $match = generateCursorQuery(params);
   const $sort = generateSort(params);
+  const $limit = params.limit + 1;
 
-  let index = _.findIndex(params.aggregation, (step) => !_.isEmpty(step.$match));
-
-  if (index < 0) {
-    params.aggregation.unshift({ $match: cursorQuery });
-    index = 0;
-  } else {
-    const matchStep = params.aggregation[index];
-
-    params.aggregation[index] = {
-      $match: {
-        $and: [cursorQuery, matchStep.$match],
-      },
-    };
+  let addFields = [];
+  let cleanUp = [];
+  if (params.sortCaseInsensitive) {
+    addFields = [{ $addFields: { __lc: { $toLower: '$' + params.paginatedField } } }];
+    cleanUp = [{ $project: { __lc: 0 } }];
   }
-
-  params.aggregation.splice(index + 1, 0, { $sort });
-  params.aggregation.splice(index + 2, 0, { $limit: params.limit + 1 });
+  const aggregation = params.aggregation.concat([
+    ...addFields,
+    { $match },
+    { $sort },
+    { $limit },
+    ...cleanUp,
+  ]);
 
   // Aggregation options:
   // https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#aggregate
   // https://mongodb.github.io/node-mongodb-native/4.0/interfaces/aggregateoptions.html
-  const options = params.options || {};
+  const options = { ...params.options };
   /**
    * IMPORTANT
    *
@@ -77,7 +79,7 @@ module.exports = async function aggregate(collection, params) {
   // https://www.npmjs.com/package/mongoist#cursor-operations
   const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
 
-  const results = await collection[aggregateMethod](params.aggregation, options).toArray();
+  const results = await collection[aggregateMethod](aggregation, options).toArray();
 
   return prepareResponse(results, params);
 };

--- a/src/find.js
+++ b/src/find.js
@@ -1,6 +1,7 @@
 const _ = require('underscore');
 const sanitizeParams = require('./utils/sanitizeParams');
 const { prepareResponse, generateSort, generateCursorQuery } = require('./utils/query');
+const aggregate = require('./aggregate');
 const config = require('./config');
 
 /**
@@ -21,6 +22,9 @@ const config = require('./config');
  *        3. Immutable. If the value changes between paged queries, it could appear twice.
  *      The default is to use the Mongo built-in '_id' field, which satisfies the above criteria.
  *      The only reason to NOT use the Mongo _id field is if you chose to implement your own ids.
+ *    -sortAscending {boolean} Whether to sort in ascending order by the `paginatedField`.
+ *    -sortCaseInsensitive {boolean} Whether to ignore case when sorting, in which case `paginatedField`
+ *      must be a string property.
  *    -next {String} The value to start querying the page.
  *    -previous {String} The value to start querying previous page.
  *    -after {String} The _id to start querying the page.
@@ -29,35 +33,45 @@ const config = require('./config');
  *    -collation {Object} An optional collation to provide to the mongo query. E.g. { locale: 'en', strength: 2 }. When null, disables the global collation.
  */
 module.exports = async function(collection, params) {
-  // Need to repeat `params.paginatedField` default value ('_id') since it's set in 'sanitizeParams()'
   const removePaginatedFieldInResponse =
     params.fields && !params.fields[params.paginatedField || '_id'];
 
-  params = _.defaults(await sanitizeParams(collection, params), { query: {} });
-  const cursorQuery = generateCursorQuery(params);
-  const $sort = generateSort(params);
+  let response;
+  if (params.sortCaseInsensitive) {
+    // For case-insensitive sorting, we need to work with an aggregation:
+    response = aggregate(collection, {
+      ...params,
+      aggregation: params.query ? [{ $match: params.query }] : [],
+    });
+  } else {
+    // Need to repeat `params.paginatedField` default value ('_id') since it's set in 'sanitizeParams()'
+    params = _.defaults(await sanitizeParams(collection, params), { query: {} });
 
-  // Support both the native 'mongodb' driver and 'mongoist'. See:
-  // https://www.npmjs.com/package/mongoist#cursor-operations
-  const findMethod = collection.findAsCursor ? 'findAsCursor' : 'find';
+    const cursorQuery = generateCursorQuery(params);
+    const $sort = generateSort(params);
 
-  const query = collection[findMethod]({ $and: [cursorQuery, params.query] }, params.fields);
+    // Support both the native 'mongodb' driver and 'mongoist'. See:
+    // https://www.npmjs.com/package/mongoist#cursor-operations
+    const findMethod = collection.findAsCursor ? 'findAsCursor' : 'find';
 
-  /**
-   * IMPORTANT
-   *
-   * If using collation, check the README:
-   * https://github.com/mixmaxhq/mongo-cursor-pagination#important-note-regarding-collation
-   */
-  const isCollationNull = params.collation === null;
-  const collation = params.collation || config.COLLATION;
-  const collatedQuery = collation && !isCollationNull ? query.collation(collation) : query;
-  // Query one more element to see if there's another page.
-  const cursor = collatedQuery.sort($sort).limit(params.limit + 1);
-  if (params.hint) cursor.hint(params.hint);
-  const results = await cursor.toArray();
+    const query = collection[findMethod]({ $and: [cursorQuery, params.query] }, params.fields);
 
-  const response = prepareResponse(results, params);
+    /**
+     * IMPORTANT
+     *
+     * If using collation, check the README:
+     * https://github.com/mixmaxhq/mongo-cursor-pagination#important-note-regarding-collation
+     */
+    const isCollationNull = params.collation === null;
+    const collation = params.collation || config.COLLATION;
+    const collatedQuery = collation && !isCollationNull ? query.collation(collation) : query;
+    // Query one more element to see if there's another page.
+    const cursor = collatedQuery.sort($sort).limit(params.limit + 1);
+    if (params.hint) cursor.hint(params.hint);
+    const results = await cursor.toArray();
+
+    response = prepareResponse(results, params);
+  }
 
   // Remove fields that we added to the query (such as paginatedField and _id) that the user didn't ask for.
   if (removePaginatedFieldInResponse) {

--- a/src/utils/sanitizeParams.js
+++ b/src/utils/sanitizeParams.js
@@ -36,7 +36,8 @@ module.exports = async function sanitizeParams(collection, params) {
       );
       if (doc) {
         // Handle usage of dot notation in paginatedField
-        const prop = getPropertyViaDotNotation(params.paginatedField, doc);
+        let prop = getPropertyViaDotNotation(params.paginatedField, doc);
+        if (params.sortCaseInsensitive) prop = prop.toLowerCase();
         params.next = [prop, params.after];
       }
     } else {
@@ -60,7 +61,8 @@ module.exports = async function sanitizeParams(collection, params) {
       );
       if (doc) {
         // Handle usage of dot notation in paginatedField
-        const prop = getPropertyViaDotNotation(params.paginatedField, doc);
+        let prop = getPropertyViaDotNotation(params.paginatedField, doc);
+        if (params.sortCaseInsensitive) prop = prop.toLowerCase();
         params.previous = [prop, params.before];
       }
     } else {


### PR DESCRIPTION
Jira: [COMM-78](https://mixmaxhq.atlassian.net/browse/COMM-78)

#### Changes Made

* Add the sort & limit stages at the end of the aggregation pipeline, instead of at the first `$match`. The previous behaviour meant, in many cases, breaking the pagination: any `$match`, `$unwind`, `$group`, etc. could change the number of items and end up returning pages with a number different from `limit`. I've checked the 4 uses of this method throughout our codebase and they are all [potentially] erroneous. In view of this, I've decided to move on, marking this as a breaking change.
* Add a `sortCaseInsensitive` option to the `aggregate` method, which will result in the results being sorted (and paginated) in case-insensitive alphabetical order.
* Use the `aggregate` method to implement the `sortCaseInsensitive` option on the `find` method too.

#### Potential Risks
- That any of existing use depends on the erroneous pagination behaviour to do its job.
- That the performance of any existing uses be affected. This would happen if the aggregation stages after the initial match are very costly, as they would be applied to the whole set matched before limiting.
- That some future use requires limiting earlier in the pipeline for performance reasons. This could be resolved by adding a marker in the pipeline (e.g. `{ $paginate }`) indicated where the pagination sort & limit steps should be added.

#### Test Plan
Tested with the Mixmax codebase.

#### Deployment plan
- Merge
