### PR TITLE
COMM-78 skip overly long commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Call `find()` with the following parameters:
         The default is to use the Mongo built-in '_id' field, which satisfies the above criteria.
         The only reason to NOT use the Mongo _id field is if you chose to implement your own ids.
       -sortAscending {Boolean} True to sort using paginatedField ascending (default is false - descending).
+      -sortCaseInsensitive {boolean} Whether to ignore case when sorting, in which case `paginatedField`
+        must be a string property.
       -next {String} The value to start querying the page.
       -previous {String} The value to start querying previous page.
    @param {Function} done Node errback style function.
@@ -327,7 +329,7 @@ If the `limit` parameter isn't passed, then this library will default to returni
 The collation to use for alphabetical sorting, both with `find` and `aggregate`, can be selected by setting `mongoPaging.config.COLLATION`. If this parameter is
 not set, no collation will be provided for the aggregation/cursor, which means that MongoDB will use whatever collation was set for the collection.
 
-## Important note regarding collation
+## (!) Important note regarding collation (!)
 
 If using a global collation setting, or a query with collation argument, ensure that your collections' indexes (that index upon string fields)
 have been created with the same collation option; if this isn't the case, your queries will be unable to

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ci:commitlint": "commitlint-jenkins --pr-only",
     "lint": "eslint .",
     "prepublishOnly": "npm run babelBuild && if [ \"$CI\" = '' ]; then node -p 'JSON.parse(process.env.npm_package_config_manualPublishMessage)'; exit 1; fi",
-    "semantic-release": "SEMANTIC_COMMITLINT_SKIP=5ed5489,e2ab709,187f1fe,0dcc73f,6d15fe5,7a05f30 semantic-release",
+    "semantic-release": "SEMANTIC_COMMITLINT_SKIP=f4543f643bac890c627d538e6200c5f5a1d45ebc semantic-release",
     "test": "DRIVER=mongoist jest && DRIVER=native jest"
   },
   "repository": {

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -25,9 +25,9 @@ const config = require('./config');
  *    -paginatedField {String} The field name to query the range for. The field must be:
  *        1. Orderable. We must sort by this value. If duplicate values for paginatedField field
  *          exist, the results will be secondarily ordered by the _id.
- *        2. Indexed. If the aggregation pipieline can return a large number of documents, this should
- *          be indexed for query performance.
- *        3. Immutable. If the value changes between paged queries, it could appear twice.
+ *        2. Immutable. If the value changes between paged queries, it could appear twice.
+ *        3. Accessible. The field must be present in the aggregation's end result so the
+ *          aggregation steps added at the end of the pipeline to implement the paging can access it.
  *      The default is to use the Mongo built-in '_id' field, which satisfies the above criteria.
  *      The only reason to NOT use the Mongo _id field is if you chose to implement your own ids.
  *    -sortAscending {boolean} Whether to sort in ascending order by the `paginatedField`.


### PR DESCRIPTION
Release broke because this repo does "squash and merge", and in doing so it uses the PR title as the title for the merge commit, and it was too long for semantic commits: https://jenkins.mixmax.com/blue/organizations/jenkins/mixmaxhq%2Fmongo-cursor-pagination/detail/master/37/pipeline/

Skipping that commit -- and, while at it, pushing a couple of doc improvements.