### PR TITLE
fix: properly page through undefs and nulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Call `find()` with the following parameters:
             exist, the results will be secondarily ordered by the _id.
           2. Indexed. For large collections, this should be indexed for query performance.
           3. Immutable. If the value changes between paged queries, it could appear twice.
-          4. Complete. A value must exist for all documents.
+          4. Consistent. All values (except undefined and null values) must be of the same type.
         The default is to use the Mongo built-in '_id' field, which satisfies the above criteria.
         The only reason to NOT use the Mongo _id field is if you chose to implement your own ids.
       -sortAscending {Boolean} True to sort using paginatedField ascending (default is false - descending).

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "mongo-cursor-pagination",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "base64-url": "^2.2.0",
-        "bson": "^4.1.0",
+        "bson": "^4.7.0",
         "object-path": "^0.11.5",
         "projection-utils": "^1.1.0",
         "semver": "^5.4.1",
@@ -32,7 +32,7 @@
         "mockgoose": "^8.0.4",
         "mongodb": "^2.2.11",
         "mongodb-memory-server": "^5.2.11",
-        "mongoist": "2.3.0",
+        "mongoist": "^2.5.5",
         "mongoose": "5.11.10",
         "prettier": "^1.19.1",
         "semantic-release": "^17.2.3"
@@ -5737,12 +5737,11 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.1.0.tgz",
-      "integrity": "sha512-xwNzRRsK2xmHvHuPESi0zVfgsm4edO47WdulNaShTriunNUMRDOAlKwpJc8zpkOXczIzbxUD7kFzhUGVYoZLDw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
       "dependencies": {
-        "buffer": "^5.1.0",
-        "long": "^4.0.0"
+        "buffer": "^5.6.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -13915,11 +13914,6 @@
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
     },
-    "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
     "node_modules/longest": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
@@ -14694,9 +14688,9 @@
       }
     },
     "node_modules/mongoist": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/mongoist/-/mongoist-2.3.0.tgz",
-      "integrity": "sha512-bwz1b/F5zZs4hI7xkgGoxHhbl5GJ/QglksqrwXORKDuHHQVnU8KPQtTXDIMkyI8T0vg4t+MCAfiV9tzk5Ggc5g==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/mongoist/-/mongoist-2.5.5.tgz",
+      "integrity": "sha512-TO4eFZhg28aC4HbGotBQTffb+oxiFPl6wzBmdLb5KxJQc8d1+w5FOPa/eNsSh5qnU6lhrXr2LlDuUNcVgr0cjA==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -33549,12 +33543,11 @@
       }
     },
     "bson": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.1.0.tgz",
-      "integrity": "sha512-xwNzRRsK2xmHvHuPESi0zVfgsm4edO47WdulNaShTriunNUMRDOAlKwpJc8zpkOXczIzbxUD7kFzhUGVYoZLDw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
       "requires": {
-        "buffer": "^5.1.0",
-        "long": "^4.0.0"
+        "buffer": "^5.6.0"
       },
       "dependencies": {
         "base64-js": {
@@ -39928,11 +39921,6 @@
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
     },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
     "longest": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
@@ -40549,9 +40537,9 @@
       }
     },
     "mongoist": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/mongoist/-/mongoist-2.3.0.tgz",
-      "integrity": "sha512-bwz1b/F5zZs4hI7xkgGoxHhbl5GJ/QglksqrwXORKDuHHQVnU8KPQtTXDIMkyI8T0vg4t+MCAfiV9tzk5Ggc5g==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/mongoist/-/mongoist-2.5.5.tgz",
+      "integrity": "sha512-TO4eFZhg28aC4HbGotBQTffb+oxiFPl6wzBmdLb5KxJQc8d1+w5FOPa/eNsSh5qnU6lhrXr2LlDuUNcVgr0cjA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/mixmaxhq/mongo-cursor-pagination#readme",
   "dependencies": {
     "base64-url": "^2.2.0",
-    "bson": "^4.1.0",
+    "bson": "^4.7.0",
     "object-path": "^0.11.5",
     "projection-utils": "^1.1.0",
     "semver": "^5.4.1",
@@ -61,7 +61,7 @@
     "mockgoose": "^8.0.4",
     "mongodb": "^2.2.11",
     "mongodb-memory-server": "^5.2.11",
-    "mongoist": "2.3.0",
+    "mongoist": "^2.5.5",
     "mongoose": "5.11.10",
     "prettier": "^1.19.1",
     "semantic-release": "^17.2.3"

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -28,6 +28,7 @@ const config = require('./config');
  *        2. Immutable. If the value changes between paged queries, it could appear twice.
  *        3. Accessible. The field must be present in the aggregation's end result so the
  *          aggregation steps added at the end of the pipeline to implement the paging can access it.
+          4. Consistent. All values (except undefined and null values) must be of the same type.
  *      The default is to use the Mongo built-in '_id' field, which satisfies the above criteria.
  *      The only reason to NOT use the Mongo _id field is if you chose to implement your own ids.
  *    -sortAscending {boolean} Whether to sort in ascending order by the `paginatedField`.

--- a/src/find.js
+++ b/src/find.js
@@ -20,6 +20,7 @@ const config = require('./config');
  *          exist, the results will be secondarily ordered by the _id.
  *        2. Indexed. For large collections, this should be indexed for query performance.
  *        3. Immutable. If the value changes between paged queries, it could appear twice.
+          4. Consistent. All values (except undefined and null values) must be of the same type.
  *      The default is to use the Mongo built-in '_id' field, which satisfies the above criteria.
  *      The only reason to NOT use the Mongo _id field is if you chose to implement your own ids.
  *    -sortAscending {boolean} Whether to sort in ascending order by the `paginatedField`.

--- a/src/utils/bsonUrlEncoding.js
+++ b/src/utils/bsonUrlEncoding.js
@@ -1,15 +1,21 @@
 const { EJSON } = require('bson');
 const base64url = require('base64-url');
 
+// BSON can't encode undefined values, so we will use this value instead:
+const BSON_UNDEFINED = '__mixmax__undefined__';
+
 /**
- * These will take a BSON object (an database result returned by the MongoDB library) and
- * encode/decode as a URL-safe string.
+ * These will take a paging handle (`next` or `previous`) and encode/decode it
+ * as a string which can be passed in a URL.
  */
 
 module.exports.encode = function(obj) {
+  if (Array.isArray(obj) && obj[0] === undefined) obj[0] = BSON_UNDEFINED;
   return base64url.encode(EJSON.stringify(obj));
 };
 
 module.exports.decode = function(str) {
-  return EJSON.parse(base64url.decode(str));
+  const obj = EJSON.parse(base64url.decode(str));
+  if (Array.isArray(obj) && obj[0] === BSON_UNDEFINED) obj[0] = undefined;
+  return obj;
 };

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -179,6 +179,20 @@ describe('find', () => {
           name: 'aleph',
         },
       ]),
+      t.db.collection('test_null_values').insert(
+        [
+          undefined,
+          undefined,
+          undefined,
+          null,
+          null,
+          'Alice',
+          'Bob',
+          'alpha',
+          'bravo',
+        ].map((name, i) => (name === undefined ? { _id: i + 1 } : { _id: i + 1, name }))
+        // Ids start with 1 because Mongoist driver doesn't support _id as 0
+      ),
     ]);
   });
 
@@ -1941,20 +1955,89 @@ describe('find', () => {
     });
   });
 
-  describe('case-insensitive sorting without collation', () => {
+  describe('sorting without collation', () => {
     let collection;
     beforeAll(() => {
       collection = t.db.collection('test_sorting');
     });
 
-    describe('by default...', () => {
+    describe('without the `sortCaseInsensitive` parameter', () => {
+      const options = {
+        paginatedField: 'name',
+        sortAscending: true,
+        limit: 2,
+      };
+
       it('sorts capital letters first', async () => {
-        const { results: results } = await paging.find(collection, {
-          paginatedField: 'name',
-          sortAscending: true,
-          limit: 2,
-        });
+        const { results: results } = await paging.find(collection, options);
         expect(_.pluck(results, 'name')).toEqual(['Alpha', 'Beta']);
+      });
+
+      it('sorts null and undefined values at the start', async () => {
+        const collection = t.db.collection('test_null_values');
+
+        const pg1 = await paging.aggregate(collection, { ...options });
+        expect(pg1.hasNext).toBe(true);
+        expect(pg1.hasPrevious).toBe(false);
+        expect(_.pluck(pg1.results, 'name')).toEqual([undefined, undefined]);
+        expect(_.pluck(pg1.results, '_id')).toEqual([1, 2]);
+
+        const pg2 = await paging.aggregate(collection, {
+          ...options,
+          next: pg1.next,
+        });
+        expect(pg2.hasNext).toBe(true);
+        expect(pg2.hasPrevious).toBe(true);
+        expect(_.pluck(pg2.results, 'name')).toEqual([undefined, null]);
+        expect(_.pluck(pg2.results, '_id')).toEqual([3, 4]);
+
+        const pg3 = await paging.aggregate(collection, {
+          ...options,
+          next: pg2.next,
+        });
+        expect(pg3.hasNext).toBe(true);
+        expect(pg3.hasPrevious).toBe(true);
+        expect(_.pluck(pg3.results, 'name')).toEqual([null, 'Alice']);
+        expect(_.pluck(pg3.results, '_id')).toEqual([5, 6]);
+
+        const pg4 = await paging.aggregate(collection, {
+          ...options,
+          next: pg3.next,
+        });
+        expect(pg4.hasNext).toBe(true);
+        expect(pg4.hasPrevious).toBe(true);
+        expect(_.pluck(pg4.results, 'name')).toEqual(['Bob', 'alpha']);
+        expect(_.pluck(pg4.results, '_id')).toEqual([7, 8]);
+
+        const pg3b = await paging.aggregate(collection, {
+          ...options,
+          previous: pg4.previous,
+        });
+        expect(pg3b.hasNext).toBe(true);
+        expect(pg3b.next).toEqual(pg3.next);
+        expect(pg3b.hasPrevious).toBe(true);
+        expect(pg3b.previous).toEqual(pg3.previous);
+        expect(pg3b.results).toEqual(pg3.results);
+
+        const pg2b = await paging.aggregate(collection, {
+          ...options,
+          previous: pg3.previous,
+        });
+        expect(pg2b.hasNext).toBe(true);
+        expect(pg2b.next).toEqual(pg2.next);
+        expect(pg2b.hasPrevious).toBe(true);
+        expect(pg2b.previous).toEqual(pg2.previous);
+        expect(pg2b.results).toEqual(pg2.results);
+
+        const pg1b = await paging.aggregate(collection, {
+          ...options,
+          previous: pg2.previous,
+        });
+        expect(pg1b.hasNext).toBe(true);
+        expect(pg1b.next).toEqual(pg1.next);
+        expect(pg1b.hasPrevious).toBe(false);
+        expect(pg1b.previous).toEqual(pg1.previous);
+        expect(pg1b.results).toEqual(pg1.results);
       });
     });
 


### PR DESCRIPTION
#### Changes Made
* Ensured that if the `paginatedField`'s value is `null` or `undefined`, it gets properly transferred via the paging handles `next` and `previous`.
* If sorting case-insensitively, replace those with the empty string for comparing, as mongodb's `$toLower` transforms both `null` and `undefined` into it.
* If sorting case-sensitively, handle each of the cases, taking into account that `undefined` sorts before `null` and `null` before everything else.
* Change the README to instruct users to avoid mixing types (before it was avoiding emtpy values).
* Updated `bson` and `mongoist` even though it was not necessary for this ticket.
 
#### Potential Risks
It is unclear whether the conditions used to check for `undefined` and `null` (or non-undefined, non-null, and combinations) will use indices efficiently. But this only happens in the specific case where this change kicks in: it will not alter the performance of existing correct code.

#### Test Plan
See unit tests.

#### Checklist
- [x] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
