### PR TITLE
fix: use the transpiled version in node 12

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-// This file was created by running mixmax-runner/scripts/migrate-module.sh
-// See mixmax-runner/scripts/unmigrate-module.sh for resetting this project
 const semver = require('semver');
 
 let main;
-if (semver.lt(process.version, '7.6.0')) {
+// We use optional chaining (?.), so we need to use the transpiled versions
+// in node versions earlier than 14.0.0:
+if (semver.lt(process.version, '14.0.0')) {
   main = require('./dist/node/index.js');
 } else {
   main = require('./src/index.js');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint .",
     "prepublishOnly": "npm run babelBuild && if [ \"$CI\" = '' ]; then node -p 'JSON.parse(process.env.npm_package_config_manualPublishMessage)'; exit 1; fi",
     "semantic-release": "SEMANTIC_COMMITLINT_SKIP=f4543f643bac890c627d538e6200c5f5a1d45ebc semantic-release",
-    "test": "DRIVER=mongoist jest && DRIVER=native jest"
+    "test": "npm run babelBuild; DRIVER=mongoist jest && DRIVER=native jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### Changes Made
* Change the version in `index.js` so the transpiled version is used in node versions ealier than 14.0.0, which is the first supporting optional chaining (`?.`).

#### Potential Risks
None perceived: even if the transpiled version is run in a version supporting optional chaining, it should still work.

#### Test Plan
Try using this package under node 12.

#### Checklist
- [ ] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
