### PR TITLE
fix: encodePaginationTokens to encode plain objects without secondary…

### DIFF
--- a/test/utils/query.test.ts
+++ b/test/utils/query.test.ts
@@ -38,6 +38,26 @@ describe('encodePaginationTokens', () => {
     expect(response.previous).toEqual(bsonUrlEncoding.encode(['Test', '456']));
   });
 
+  it('encodes tokens when cursor is a plain object that lacks _id', () => {
+    const params = {
+      paginatedField: 'name',
+    };
+
+    const response = {
+      results: [],
+      previous: { name: 'Alpha' },   // ⬅️ no _id
+      hasPrevious: false,
+      next: { name: 'Beta' },        // ⬅️ no _id
+      hasNext: false,
+    } as any;
+
+    encodePaginationTokens(params, response);
+
+    expect(response.previous).toEqual(bsonUrlEncoding.encode('Alpha'));
+    expect(response.next).toEqual(bsonUrlEncoding.encode('Beta'));
+  });
+
+
   describe('generateCursorQuery', () => {
     it('generates an empty cursor query when no next or previous cursor is provided', () => {
       const params = {


### PR DESCRIPTION
… sort ID

<!-- Author/Reviewer expectations are described in the last comment -->

> **Note** - Since this is a public repository, make sure that we're not publishing private data in the code, commit comments, or this PR.

> **Note for reviewers** - Please add a 2nd reviewer if the PR affects more than 15 files or 100 lines (not counting
  `package-lock.json`), if it incurs significant risk, or if it is going through a 2nd review+fix cycle.

## 📚 Context/Description Behind The Change
Reviewing the [original JS code](https://github.com/mixmaxhq/mongo-cursor-pagination/blob/d29a49e0925aa5f6c7010d0ea9804cd3bb3bb73b/src/utils/query.js#L20-L45) (converted to TS in [this PR](https://github.com/mixmaxhq/mongo-cursor-pagination/pull/367/files?show-deleted-files=true&show-viewed-files=true&file-filters%5B%5D=)) we always encode when shouldSecondarySortOnId is true. 

With the new guard the branch is silently skipped whenever the cursor object isn’t a plain object that passes the guard.

Two common scenarios fail:
1. Mongoose documents / BSON objects – they are special objects whose prototype sometimes hides properties from the in operator.
3. A second call to prepareResponse on the same response (e.g., in tests) – after the first run previous/next are strings, so the second run will now bail out and leave them as raw objects, breaking callers that expect strings.


## 🚨 Potential Risks & What To Monitor After Deployment
We need to test any usages of this method

## 🧑‍🔬 How Has This Been Tested?
- Unit tests
- will test by importing service tasks and testing issue in PLAT-186 

## 🚚 Release Plan




<!--
  ## 🤝 Expectations

  When Opening/Reviewing a PR, please keep in mind:

  ### As the PR Author
  - Provide all the necessary context on "Why" you have performed your changes
  - Assume that the reviewer has no previous knowledge about the codebase: would he/she be able to
    review it the way it is right now?
  - If changes are extensive, break them into smaller commits that tell a story, instead of 1 commit
    with 15 files changed.
  - Split Refactors and New-Code-Changes into different commits, ideally: different PRs.
  - Test your code before requesting review — unless some rare exceptions, we shouldn't ship any code
    without testing it before.
  - If your PR is UI related, consider adding screenshots/videos with the behavior and before/after.

  ### As the PR Reviewer
  - Be kind. Don't nitpick.
  - Expect to have all the necessary context to review the PR on (or linked on) the PR itself.
  - When in doubt: ask.
  - Validate if the author's tests have any missing coverage points. Do not approve an untested PR.
  - Pay extra attention to the "Potential Risks" and "Release Plan" sections.
  - If the PR alters the product UI, consider checking out the branch to visually inspect it.
-->
